### PR TITLE
A new valid placement area calculation method

### DIFF
--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -139,8 +139,8 @@ class BridsonFillStrategy(FillStrategy):
                 while active:
                     # If we have active points, do the Poisson disc sampling
                     base = active.pop()
-                    for _ in range(self.k):
-                        point = self._generate_random_point_in_disc(base)
+                    random_points = self._generate_bridson_points(base)
+                    for point in random_points:
                         if self._is_valid(point):
                             x_i, y_i = self._cell_index(point)
                             self._points[y_i][x_i] = point
@@ -193,11 +193,22 @@ class BridsonFillStrategy(FillStrategy):
         y = self.y_range[0] + (i + random.random()) * self._cell_size
         return (int(round(x)), int(round(y)))
     
-    def _generate_random_point_in_disc(self, base):
-        r = math.sqrt(3 * random.random() + 1) * self.centre_spacing
-        th = random.uniform(0, math.pi)
-        return (int(round(base[0] + r * math.sin(th))), int(round(base[1] + r * math.cos(th))))
-
+    def _generate_bridson_points(self, base):
+        points = []
+        for j in range(self.k):
+            r = math.sqrt(3 * random.random() + 1) * self.centre_spacing
+            th = random.uniform(0, 2 * math.pi)
+            points.append((int(round(base[0] + r * math.sin(th))), int(round(base[1] + r * math.cos(th)))))
+        return points
+    
+    def _generate_roberts_points(self, base):
+        points = []
+        r = self.centre_spacing + 2
+        seed = random.uniform(0, 2 * math.pi)
+        for j in range(self.k):
+            th = 2 * math.pi * j / k + seed
+            points.append((int(round(base[0] + r * math.sin(th))), int(round(base[1] + r * math.cos(th)))))
+        return points
 
 class FillArea:
 

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -101,7 +101,22 @@ class GridFillStrategy(FillStrategy):
         return points
 
 
-StarFillStrategy = GridFillStrategy
+class StarFillStrategy(FillStrategy):
+    def generate_points(self):
+        # x spacing is 2 * spacing / sqrt(2), y spacing is spacing / sqrt(2)
+        spacing = self.centre_spacing / math.sqrt(2)
+        x_steps = int((self.x_range[1] - self.x_range[0]) / 2 * spacing) + 1
+        y_steps = int((self.y_range[1] - self.y_range[0]) / spacing) + 1
+
+        points = []
+        for x_i in range(x_steps):
+            for y_i in range(y_steps):
+                x = int(round(x_i * 2 * spacing + self.x_range[0] + (spacing if y_i % 2 else 0.0)))
+                y = int(round(y_i * spacing + self.y_range[0]))
+                if self.valid_predicate(x, y):
+                    points.append((x, y))
+        
+        return points
 
 
 class BridsonFillStrategy(FillStrategy):
@@ -403,7 +418,7 @@ class FillArea:
         
         # Deflate by our via radius + clearance, and we have polygon encompassing where we can
         # place via centers on the top.
-        valid.Inflate(-int(math.round(self.clearance)) - int(self.size) // 2, 36)
+        valid.Inflate(-int(round(self.clearance + self.size / 2)), 36)
 
         return valid
 

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -101,6 +101,9 @@ class GridFillStrategy(FillStrategy):
         return points
 
 
+StarFillStrategy = GridFillStrategy
+
+
 class BridsonFillStrategy(FillStrategy):
     """
     This fill stragegy implements Bridsons Poisson disc sampling algorithm to generate
@@ -370,7 +373,13 @@ class FillArea:
         x_range = (bounds.GetLeft(), bounds.GetRight())
         y_range = (bounds.GetTop(), bounds.GetBottom())
         valid_predicate = lambda x, y: valid.Contains(VECTOR2I(x, y))
-        points = BridsonFillStrategy(x_range, y_range, valid_predicate, self.step).generate_points()
+        if self.random:
+            strategy = BridsonFillStrategy
+        elif self.star:
+            strategy = StarFillStrategy
+        else:
+            strategy = GridFillStrategy
+        points = strategy(x_range, y_range, valid_predicate, self.step).generate_points()
         for x, y in points:
             self.AddVia(wxPoint(x, y))
 

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -105,7 +105,7 @@ class StarFillStrategy(FillStrategy):
     def generate_points(self):
         # x spacing is 2 * spacing / sqrt(2), y spacing is spacing / sqrt(2)
         spacing = self.centre_spacing / math.sqrt(2)
-        x_steps = int((self.x_range[1] - self.x_range[0]) / 2 * spacing) + 1
+        x_steps = int((self.x_range[1] - self.x_range[0]) / (2 * spacing)) + 1
         y_steps = int((self.y_range[1] - self.y_range[0]) / spacing) + 1
 
         points = []

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -174,7 +174,7 @@ class BridsonFillStrategy(FillStrategy):
             return False
         
         # Check surrounding points
-        for ox_i, oy_i in ((-1, -1), (-1, 0), (-1, 1), (0, 1), (1, 1), (1, 0), (1, -1), (0, -1)):
+        for ox_i, oy_i in ((-1, -1), (-1, 0), (-1, 1), (0, 1), (1, 1), (1, 0), (1, -1), (0, -1), (-2, 0), (0, 2), (2, 0), (0, -2)):
             px_i = x_i + ox_i
             py_i = y_i + oy_i
             if px_i < 0 or px_i >= self._x_steps or py_i < 0 or py_i >= self._y_steps:

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -194,8 +194,11 @@ class FillArea:
         all_areas = [self.pcb.GetArea(i) for i in xrange(self.pcb.GetAreaCount())]
         target_areas = filter(lambda x: (x.GetNetname() == self.netname and (x.IsOnLayer(F_Cu) or x.IsOnLayer(B_Cu))), all_areas)
 
-        # TODO: Validate that we don't have any top/bottom no-net layers already. If we do, we can't run this as we'd mess
+        # Validate that we don't have any top/bottom no-net layers already. If we do, we can't run this as we'd mess
         # them up when switching the net back.
+        if list(filter(lambda x: (x.GetNetname() == '' and (x.IsOnLayer(F_Cu) or x.IsOnLayer(B_Cu))), all_areas)):
+            wxPrint("Sorry, we can't run via stitching if there are no-net zones on top/bottom copper layers.")
+            return
         
         # Change the net of the target areas to "No Net" and refill. That way we'll get a full fill
         # including islands

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -219,11 +219,11 @@ class FillArea:
         """
 
         all_areas = [self.pcb.GetArea(i) for i in xrange(self.pcb.GetAreaCount())]
-        target_areas = filter(lambda x: (x.GetNetname() == self.netname and (x.IsOnLayer(F_Cu) or x.IsOnLayer(B_Cu))), all_areas)
+        target_areas = filter(lambda x: (x.GetNetname() == self.netname and (x.IsOnLayer(F_Cu) or x.IsOnLayer(B_Cu)) and not x.GetIsKeepout()), all_areas)
 
         # Validate that we don't have any top/bottom no-net layers already. If we do, we can't run this as we'd mess
         # them up when switching the net back.
-        if any(filter(lambda x: (x.GetNetname() == '' and (x.IsOnLayer(F_Cu) or x.IsOnLayer(B_Cu))), all_areas)):
+        if any(filter(lambda x: (x.GetNetname() == '' and (x.IsOnLayer(F_Cu) or x.IsOnLayer(B_Cu)) and not x.GetIsKeepout()), all_areas)):
             wxPrint("Sorry, we can't run via stitching if there are no-net zones on top/bottom copper layers.")
             return
         
@@ -235,8 +235,8 @@ class FillArea:
 
         # Search for areas on top/bottom layers
         all_areas = [self.pcb.GetArea(i) for i in xrange(self.pcb.GetAreaCount())]
-        top_areas = filter(lambda x: (x.GetNetname() == '' and x.IsOnLayer(F_Cu)), all_areas)
-        bot_areas = filter(lambda x: (x.GetNetname() == '' and x.IsOnLayer(B_Cu)), all_areas)
+        top_areas = filter(lambda x: (x.GetNetname() == '' and x.IsOnLayer(F_Cu) and not x.GetIsKeepout()), all_areas)
+        bot_areas = filter(lambda x: (x.GetNetname() == '' and x.IsOnLayer(B_Cu) and not x.GetIsKeepout()), all_areas)
         
         # Calculate where it'd be valid to put vias that hit both top/bottom layers in the
         # filled areas, without the annulus going outside of them.
@@ -255,7 +255,7 @@ class FillArea:
 
         # Reset target area nets to original and refill
         all_areas = [self.pcb.GetArea(i) for i in xrange(self.pcb.GetAreaCount())]
-        target_areas = filter(lambda x: (x.GetNetname() == '' and (x.IsOnLayer(F_Cu) or x.IsOnLayer(B_Cu))), all_areas)
+        target_areas = filter(lambda x: (x.GetNetname() == '' and (x.IsOnLayer(F_Cu) or x.IsOnLayer(B_Cu)) and not x.GetIsKeepout()), all_areas)
         for area in target_areas:
             area.SetNet(self.pcb.GetNetsByName()[self.netname])
         self.RefillBoardAreas()

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -70,21 +70,7 @@ FillArea.FillArea().SetDebug().SetNetname("GND").SetStepMM(1.27).SetSizeMM(0.6).
 
 #  You can also use it in command line. In this case, the first parameter is
 # the pcb file path. Default options are applied.
-
 """
-
-
-class ViaObject:
-
-    """
-    ViaObject holds all information of a single Via
-    """
-
-    def __init__(self, x, y, pos_x, pos_y):
-        self.X = x
-        self.Y = y
-        self.PosX = pos_x
-        self.PosY = pos_y
 
 
 class FillArea:
@@ -93,15 +79,6 @@ class FillArea:
     Automaticaly add via on area where there are no track/existing via,
     pads and keepout areas
     """
-
-    REASON_OK = 0
-    REASON_NO_SIGNAL = 1
-    REASON_OTHER_SIGNAL = 2
-    REASON_KEEPOUT = 3
-    REASON_TRACK = 4
-    REASON_PAD = 5
-    REASON_DRAWING = 6
-    REASON_STEP = 7
 
     def __init__(self, filename=None):
         self.filename = None
@@ -189,49 +166,7 @@ class FillArea:
         self.clearance = float(FromMM(s))
         return self
 
-    def GetReasonSymbol(self, reason):
-        if isinstance(reason, ViaObject):
-            return "X"
-        if reason == self.REASON_NO_SIGNAL:
-            return " "
-        if reason == self.REASON_OTHER_SIGNAL:
-            return "O"
-        if reason == self.REASON_KEEPOUT:
-            return "K"
-        if reason == self.REASON_TRACK:
-            return "T"
-        if reason == self.REASON_PAD:
-            return "P"
-        if reason == self.REASON_DRAWING:
-            return "D"
-        if reason == self.REASON_STEP:
-            return "-"
-
-        return str(reason)
-
-    def PrintRect(self, rectangle):
-        """debuging tool
-        Print board in ascii art
-        """
-        print("_" * (len(rectangle)+2))
-        for y in range(len(rectangle[0])):
-            print("|", end='')
-            for x in range(len(rectangle)):
-                print("%s" % self.GetReasonSymbol(rectangle[x][y]), end='')
-            print("|")
-        print("_" * (len(rectangle)+2))
-        print('''
-OK           = 'X'
-NO_SIGNAL    = ' '
-OTHER_SIGNAL = 'O'
-KEEPOUT      = 'K'
-TRACK        = 'T'
-PAD          = 'P'
-DRAWING      = 'D'
-STEP         = '-'
-''')
-
-    def AddVia(self, position, x, y):
+    def AddVia(self, position):
         m = VIA(self.pcb)
         m.SetPosition(position)
         m.SetNet(self.pcb.FindNet(self.netname))
@@ -251,324 +186,66 @@ STEP         = '-'
         filler = ZONE_FILLER(self.pcb)
         filler.Fill(self.pcb.Zones())
 
-    def CheckViaInAllAreas(self, via, all_areas):
-        '''
-        Checks if an existing Via collides with another area
-        '''
-        # Enum all area
-        for area in all_areas:
-            area_layer = area.GetLayer()
-            area_clearance = area.GetClearance()
-            area_priority = area.GetPriority()
-            is_keepout_area = area.GetIsKeepout()
-            is_target_net = (area.GetNetname() == self.netname)  # (area.GetNetname().upper() == self.netname)
-            # wx.LogMessage(area.GetNetname()) #wx.LogMessage(area.GetNetname().upper())
-
-            if (not is_target_net):                                                         # Only process areas that are not in the target net
-                # Offset is half the size of the via plus the clearance of the via or the area
-                offset = max(self.clearance, area_clearance) + self.size / 2
-                for dx in [-offset, offset]:
-                    # All 4 corners of the via are testet (upper, lower, left, right) but not the center
-                    for dy in [-offset, offset]:
-                        point_to_test = wxPoint(via.PosX + dx, via.PosY + dy)
-
-                        hit_test_area = area.HitTestFilledArea(point_to_test)             # Collides with a filled area
-                        hit_test_edge = area.HitTestForEdge(point_to_test, 1)              # Collides with an edge/corner
-                        try:
-                            hit_test_zone = area.HitTestInsideZone(point_to_test)         # Is inside a zone (e.g. KeepOut)
-                        except:
-                            hit_test_zone = False
-                            wxPrint('exception: missing HitTestInsideZone: To Be Fixed')
-                            # hit_test_zone   = area.HitTest(point_to_test)              # Is inside a zone (e.g. KeepOut) kicad nightly 5.99
-                        if is_keepout_area and (hit_test_area or hit_test_edge or hit_test_zone):
-                            return self.REASON_KEEPOUT                                      # Collides with keepout
-
-                        elif (hit_test_area or hit_test_edge):
-                            # Collides with another signal (e.g. on another layer)
-                            return self.REASON_OTHER_SIGNAL
-
-                        elif hit_test_zone:
-                            # Check if the zone is higher priority than other zones of the target net in the same point
-                            #target_areas_on_same_layer = filter(lambda x: ((x.GetPriority() > area_priority) and (x.GetLayer() == area_layer) and (x.GetNetname().upper() == self.netname)), all_areas)
-                            target_areas_on_same_layer = filter(lambda x: ((x.GetPriority() > area_priority) and (
-                                x.GetLayer() == area_layer) and (x.GetNetname() == self.netname)), all_areas)
-                            for area_with_higher_priority in target_areas_on_same_layer:
-                                if area_with_higher_priority.HitTestInsideZone(point_to_test):
-                                    break                                                   # Area of target net has higher priority on this layer
-                            else:
-                                # Collides with another signal (e.g. on another layer)
-                                return self.REASON_OTHER_SIGNAL
-
-        return self.REASON_OK
-
-    def ClearViaInStepSize(self, rectangle, x, y, distance):
-        '''
-        Stepsize==0
-            O O O O O O O O O
-            O O O O O O O O O
-            O O O O O O O O O
-            O O O O O O O O O
-            O O O O O O O O O
-            O O O O O O O O O
-            O O O O O O O O O
-
-        Standard
-            O   O   O   O   O
-
-            O   O   O   O   O
-
-            O   O   O   O   O
-
-            O   O   O   O   O
-
-        Star
-            O   O   O   O   O
-              O   O   O   O
-            O   O   O   O   O
-              O   O   O   O
-            O   O   O   O   O
-              O   O   O   O
-            O   O   O   O   O
-        '''
-        for x_pos in range(x-distance, x+distance+1):
-            if (x_pos >= 0) and (x_pos < len(rectangle)):
-                distance_y = distance-abs(x-x_pos) if self.star else distance       # Star or Standard shape
-                for y_pos in range(y-distance_y, y+distance_y+1):
-                    if (y_pos >= 0) and (y_pos < len(rectangle[0])):
-                        if (x_pos == x) and (y_pos == y):
-                            continue
-                        rectangle[x_pos][y_pos] = self.REASON_STEP
-
     def Run(self):
         """
         Launch the process
         """
-        target_tracks = self.pcb.GetTracks()
 
-        if self.delete_vias:
-            # timestmap again available
-            #target_tracks = filter(lambda x: (x.GetNetname().upper() == self.netname), self.pcb.GetTracks())
-            target_tracks = filter(lambda x: (x.GetNetname() == self.netname), self.pcb.GetTracks())
-            target_tracks_cp = list(target_tracks)
-            l = len (target_tracks_cp)
-            for i in range(l):
-                if target_tracks_cp[i].Type() == PCB_VIA_T:
-                    if target_tracks_cp[i].GetTimeStamp() == 33:
-                        self.pcb.RemoveNative(target_tracks_cp[i])
-            self.RefillBoardAreas()
-            return                                          # no need to run the rest of logic
-
-        lboard = self.pcb.ComputeBoundingBox(False)
-        origin = lboard.GetPosition()
-
-        # Create an initial rectangle: all is set to "REASON_NO_SIGNAL"
-        # get a margin to avoid out of range
-        l_clearance = self.clearance + self.size
-        x_limit = int((lboard.GetWidth() + l_clearance) / l_clearance) + 1
-        y_limit = int((lboard.GetHeight() + l_clearance) / l_clearance) + 1
-
-        rectangle = [[self.REASON_NO_SIGNAL]*y_limit for i in xrange(x_limit)]
-
-        all_pads = self.pcb.GetPads()
-        all_tracks = self.pcb.GetTracks()
-        try:
-            all_drawings = filter(lambda x: x.GetClass() == 'PTEXT' and self.pcb.GetLayerID(
-                x.GetLayerName()) in (F_Cu, B_Cu), self.pcb.DrawingsList())
-        except:
-            all_drawings = filter(lambda x: x.GetClass() == 'PTEXT' and self.pcb.GetLayerID(
-                x.GetLayerName()) in (F_Cu, B_Cu), self.pcb.Drawings())
-            #wxPrint("exception on missing BOARD.DrawingsList")
         all_areas = [self.pcb.GetArea(i) for i in xrange(self.pcb.GetAreaCount())]
-        # target_areas    = filter(lambda x: (x.GetNetname().upper() == self.netname), all_areas)         # KeepOuts are filtered because they have no name
-        # KeepOuts are filtered because they have no name
-        target_areas = filter(lambda x: (x.GetNetname() == self.netname), all_areas)
+        target_areas = filter(lambda x: (x.GetNetname() == self.netname and (x.IsOnLayer(F_Cu) or x.IsOnLayer(B_Cu))), all_areas)
 
-        via_list = []       # Create a list of existing vias => faster than scanning through the whole rectangle
-        max_target_area_clearance = 0
-
-        # Enum all target areas (Search possible positions for vias on the target net)
+        # TODO: Validate that we don't have any top/bottom no-net layers already. If we do, we can't run this as we'd mess
+        # them up when switching the net back.
+        
+        # Change the net of the target areas to "No Net" and refill. That way we'll get a full fill
+        # including islands
         for area in target_areas:
-            wxPrint("Processing Target Area: %s, LayerName: %s..." % (area.GetNetname(), area.GetLayerName()))
-
-            is_selected_area = area.IsSelected()
-            area_clearance = area.GetClearance()
-            if max_target_area_clearance < area_clearance:
-                max_target_area_clearance = area_clearance
-
-            if (not self.only_selected_area) or (self.only_selected_area and is_selected_area):         # All areas or only the selected area
-                # Check every possible point in the virtual coordinate system
-                for x in xrange(len(rectangle)):
-                    for y in xrange(len(rectangle[0])):
-                        # No other "target area" found yet => go on with processing
-                        if rectangle[x][y] == self.REASON_NO_SIGNAL:
-                            current_x = origin.x + (x * l_clearance)                                    # Center of the via
-                            current_y = origin.y + (y * l_clearance)
-
-                            test_result = True                                                          # Start with true, if a check fails, it is set to false
-
-                            # Offset is half the size of the via plus the clearance of the via or the area
-                            offset = max(self.clearance, area_clearance) + self.size / 2
-                            for dx in [-offset, offset]:
-                                # All 4 corners of the via are testet (upper, lower, left, right) but not the center
-                                for dy in [-offset, offset]:
-                                    point_to_test = wxPoint(current_x + dx, current_y + dy)
-                                    hit_test_area = area.HitTestFilledArea(point_to_test)             # Collides with a filled area
-                                    # Collides with an edge/corner
-                                    hit_test_edge = area.HitTestForEdge(point_to_test, area_clearance)
-
-                                    # test_result only remains true if the via is inside an area and not on an edge
-                                    test_result &= (hit_test_area and not hit_test_edge)
-
-                            if test_result:
-                                # Create a via object with information about the via and place it in the rectangle
-                                via_obj = ViaObject(x=x, y=y, pos_x=current_x, pos_y=current_y)
-                                rectangle[x][y] = via_obj
-                                via_list.append(via_obj)
-
-        if self.debug:
-            wxPrint("\nPost target areas:")
-            self.PrintRect(rectangle)
-
-        # Enum all vias
-        wxPrint("Processing all vias of target area...")
-        for via in via_list:
-            reason = self.CheckViaInAllAreas(via, all_areas)
-            if reason != self.REASON_OK:
-                rectangle[via.X][via.Y] = reason
-
-        if self.debug:
-            wxPrint("\nPost areas:")
-            self.PrintRect(rectangle)
-
-        # Same job with all pads => all pads on all layers
-        wxPrint("Processing all pads...")
-        for pad in all_pads:
-            local_offset = max(pad.GetClearance(), self.clearance, max_target_area_clearance) + (self.size / 2)
-            max_size = max(pad.GetSize().x, pad.GetSize().y)
-
-            start_x = int(floor(((pad.GetPosition().x - (max_size / 2.0 + local_offset)) - origin.x) / l_clearance))
-            stop_x = int(ceil(((pad.GetPosition().x + (max_size / 2.0 + local_offset)) - origin.x) / l_clearance))
-
-            start_y = int(floor(((pad.GetPosition().y - (max_size / 2.0 + local_offset)) - origin.y) / l_clearance))
-            stop_y = int(ceil(((pad.GetPosition().y + (max_size / 2.0 + local_offset)) - origin.y) / l_clearance))
-
-            for x in range(start_x, stop_x + 1):
-                for y in range(start_y, stop_y + 1):
-                    try:
-                        if isinstance(rectangle[x][y], ViaObject):
-                            start_rect = wxPoint(origin.x + (l_clearance * x) - local_offset,
-                                                 origin.y + (l_clearance * y) - local_offset)
-                            size_rect = wxSize(2 * local_offset, 2 * local_offset)
-                            if pad.HitTest(EDA_RECT(start_rect, size_rect), False):
-                                rectangle[x][y] = self.REASON_PAD
-                    except:
-                        wxPrint("exception on Processing all pads...")
-        if self.debug:
-            wxPrint("\nPost pads:")
-            self.PrintRect(rectangle)
-
-        # Same job with tracks => all tracks on all layers
-        wxPrint("Processing all tracks...")
-        for track in all_tracks:
-            start_x = track.GetStart().x
-            start_y = track.GetStart().y
-
-            stop_x = track.GetEnd().x
-            stop_y = track.GetEnd().y
-
-            if start_x > stop_x:
-                d = stop_x
-                stop_x = start_x
-                start_x = d
-
-            if start_y > stop_y:
-                d = stop_y
-                stop_y = start_y
-                start_y = d
-
-            osx = start_x
-            osy = start_y
-            opx = stop_x
-            opy = stop_y
-
-            clearance = max(track.GetClearance(), self.clearance, max_target_area_clearance) + (self.size / 2) + (track.GetWidth() / 2)
-
-            start_x = int(floor(((start_x - clearance) - origin.x) / l_clearance))
-            stop_x = int(ceil(((stop_x + clearance) - origin.x) / l_clearance))
-
-            start_y = int(floor(((start_y - clearance) - origin.y) / l_clearance))
-            stop_y = int(ceil(((stop_y + clearance) - origin.y) / l_clearance))
-
-            for x in range(start_x, stop_x + 1):
-                for y in range(start_y, stop_y + 1):
-                    try:
-                        if isinstance(rectangle[x][y], ViaObject):
-                            start_rect = wxPoint(origin.x + (l_clearance * x) - clearance,
-                                                 origin.y + (l_clearance * y) - clearance)
-                            size_rect = wxSize(2 * clearance, 2 * clearance)
-                            if track.HitTest(EDA_RECT(start_rect, size_rect), False):
-                                rectangle[x][y] = self.REASON_TRACK
-                    except:
-                        wxPrint("exception on Processing all tracks...")
-
-        if self.debug:
-            wxPrint("\nPost tracks:")
-            self.PrintRect(rectangle)
-
-        # Same job with existing text
-        wxPrint("Processing all existing drawings...")
-        for draw in all_drawings:
-            inter = float(self.clearance + self.size)
-            bbox = draw.GetBoundingBox()
-
-            start_x = int(floor(((bbox.GetPosition().x - inter) - origin.x) / l_clearance))
-            stop_x = int(ceil(((bbox.GetPosition().x + (bbox.GetSize().x + inter)) - origin.x) / l_clearance))
-
-            start_y = int(floor(((bbox.GetPosition().y - inter) - origin.y) / l_clearance))
-            stop_y = int(ceil(((bbox.GetPosition().y + (bbox.GetSize().y + inter)) - origin.y) / l_clearance))
-
-            for x in range(start_x, stop_x + 1):
-                for y in range(start_y, stop_y + 1):
-                    rectangle[x][y] = self.REASON_DRAWING
-
-        if self.debug:
-            wxPrint("Post Drawnings:")
-            self.PrintRect(rectangle)
-
-        wxPrint("Remove vias to guarantee step size...")
-        clear_distance = 0
-        if self.step != 0.0:
-            # How much "via steps" should be removed around a via (round up)
-            clear_distance = int((self.step+l_clearance) / l_clearance)
-
-        via_placed = 0
-        for x in xrange(len(rectangle)):
-            for y in xrange(len(rectangle[0])):
-                if isinstance(rectangle[x][y], ViaObject):
-                    if clear_distance:
-                        self.ClearViaInStepSize(rectangle, x, y, clear_distance)
-
-                    via = rectangle[x][y]
-                    ran_x = 0
-                    ran_y = 0
-
-                    if self.random:
-                        ran_x = (random.random() * l_clearance / 2.0) - (l_clearance / 4.0)
-                        ran_y = (random.random() * l_clearance / 2.0) - (l_clearance / 4.0)
-
-                    self.AddVia(wxPoint(via.PosX + ran_x, via.PosY + ran_y), via.X, via.Y)
-                    via_placed += 1
-
-        if self.debug:
-            wxPrint("\nFinal result:")
-            self.PrintRect(rectangle)
-
+            area.SetNet(self.pcb.GetNetsByName()[''])
         self.RefillBoardAreas()
 
-        if self.filename:
-            self.pcb.Save(self.filename)
-        msg = "{:d} vias placed\n".format(via_placed)
-        wxPrint(msg+"Done!")
+        # Search for areas on top/bottom layers
+        all_areas = [self.pcb.GetArea(i) for i in xrange(self.pcb.GetAreaCount())]
+        top_areas = filter(lambda x: (x.GetNetname() == '' and x.IsOnLayer(F_Cu)), all_areas)
+        bot_areas = filter(lambda x: (x.GetNetname() == '' and x.IsOnLayer(B_Cu)), all_areas)
+        
+        # Calculate where it'd be valid to put vias that hit both top/bottom layers in the
+        # filled areas, without the annulus going outside of them.
+        valid = self._get_valid_placement_area(top_areas)
+        valid.BooleanIntersection(self._get_valid_placement_area(bot_areas), SHAPE_POLY_SET.PM_STRICTLY_SIMPLE)
+        
+        # Place vias in a grid wherever we can.
+        lboard = self.pcb.ComputeBoundingBox(False)
+        origin = lboard.GetPosition()
+        x_limit = int((lboard.GetWidth() + self.step) / self.step) + 1
+        y_limit = int((lboard.GetHeight() + self.step) / self.step) + 1
+        for x_i in range(x_limit):
+            for y_i in range(y_limit):
+                point = origin + wxPoint(x_i * self.step, y_i * self.step)
+                if valid.Contains(VECTOR2I(point)):
+                    self.AddVia(point, 0, 0)
+
+        # Reset target area nets to original and refill
+        all_areas = [self.pcb.GetArea(i) for i in xrange(self.pcb.GetAreaCount())]
+        target_areas = filter(lambda x: (x.GetNetname() == '' and (x.IsOnLayer(F_Cu) or x.IsOnLayer(B_Cu))), all_areas)
+        for area in target_areas:
+            area.SetNet(self.pcb.GetNetsByName()[self.netname])
+        self.RefillBoardAreas()
+    
+    def _get_valid_placement_area(self, areas):
+        # Get some polygons for top/bottom with a buffer.
+        valid = SHAPE_POLY_SET()
+
+        for area in areas:
+            # Clone and inflate polys by the min width / 2. KiCAD seems to store them as polygons
+            # with a line width, not as polys with a 0 line width.
+            poly = SHAPE_POLY_SET(area.GetFilledPolysList(), True)
+            poly.Inflate(area.GetMinThickness() // 2, 36)
+            valid.BooleanAdd(poly, SHAPE_POLY_SET.PM_STRICTLY_SIMPLE)
+        
+        # Deflate by our via radius, and we have polygon encompassing where we can place via centers on the top.
+        valid.Inflate(-int(self.size) // 2, 36)
+
+        return valid
 
 
 if __name__ == '__main__':

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -196,7 +196,7 @@ class FillArea:
 
         # Validate that we don't have any top/bottom no-net layers already. If we do, we can't run this as we'd mess
         # them up when switching the net back.
-        if list(filter(lambda x: (x.GetNetname() == '' and (x.IsOnLayer(F_Cu) or x.IsOnLayer(B_Cu))), all_areas)):
+        if any(filter(lambda x: (x.GetNetname() == '' and (x.IsOnLayer(F_Cu) or x.IsOnLayer(B_Cu))), all_areas)):
             wxPrint("Sorry, we can't run via stitching if there are no-net zones on top/bottom copper layers.")
             return
         

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -381,8 +381,9 @@ class FillArea:
             poly.Inflate(area.GetMinThickness() // 2, 36)
             valid.BooleanAdd(poly, SHAPE_POLY_SET.PM_STRICTLY_SIMPLE)
         
-        # Deflate by our via radius, and we have polygon encompassing where we can place via centers on the top.
-        valid.Inflate(-int(self.size) // 2, 36)
+        # Deflate by our via radius + clearance, and we have polygon encompassing where we can
+        # place via centers on the top.
+        valid.Inflate(-int(math.round(self.clearance)) - int(self.size) // 2, 36)
 
         return valid
 

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -437,8 +437,28 @@ class FillArea:
             area.AppendCorner(wxPoint(bounds.GetRight(), bounds.GetBottom()), -1)
             area.AppendCorner(wxPoint(bounds.GetLeft(), bounds.GetBottom()), -1)
             area.SetTimeStamp(34)
+            area.SetMinThickness(FromMM(0.04))
+            area.SetThermalReliefCopperBridge(FromMM(0.5))
+            area.SetZoneClearance(0)
+            area.SetThermalReliefGap(0)
+            area.SetPadConnection(0)
+        
         self.RefillBoardAreas()
 
+        allowed = None
+        for areas in self._get_areas_on_copper('', False, 34).values():
+            for area in areas:
+                poly = SHAPE_POLY_SET(area.GetFilledPolysList(), True)
+                poly.Inflate(FromMM(0.02), 36)
+                if allowed is None:
+                    allowed = poly
+                else:
+                    allowed.BooleanIntersection(poly, SHAPE_POLY_SET.PM_STRICTLY_SIMPLE)
+                self.pcb.RemoveArea(None, area)
+        
+        allowed.Inflate(-int(round(self.clearance + self.size / 2)), 36)
+
+        return allowed
     
     def _get_areas_on_copper(self, net_name=None, only_selected=False, timestamp=None):
         predicate = lambda x: (

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -328,6 +328,17 @@ class FillArea:
         Launch the process
         """
 
+        if self.delete_vias:
+            target_tracks = filter(lambda x: (x.GetNetname() == self.netname), self.pcb.GetTracks())
+            target_tracks_cp = list(target_tracks)
+            l = len (target_tracks_cp)
+            for i in range(l):
+                if target_tracks_cp[i].Type() == PCB_VIA_T:
+                    if target_tracks_cp[i].GetTimeStamp() == 33:
+                        self.pcb.RemoveNative(target_tracks_cp[i])
+            self.RefillBoardAreas()
+            return
+
         all_areas = [self.pcb.GetArea(i) for i in xrange(self.pcb.GetAreaCount())]
         target_areas = filter(lambda x: (x.GetNetname() == self.netname and (x.IsOnLayer(F_Cu) or x.IsOnLayer(B_Cu)) and not x.GetIsKeepout()), all_areas)
 

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -357,27 +357,29 @@ class FillArea:
             self.RefillBoardAreas()
             return
         
-        allowed_areas = self._get_allowed_areas()
-
-        '''
-        # Get target areas for all layers
+        # Get target areas for all layers, and move them off the PCB.
         target_areas = self._get_areas_on_copper(self.netname, self.only_selected_area)
+        move_vector = wxPoint(self.pcb.GetBoundingBox().GetWidth() * 2, self.pcb.GetBoundingBox().GetHeight() * 2)
+        for areas in target_areas.values():
+            for area in areas:
+                area.Move(move_vector)
 
-        # Set them to "No Net" and refill. That way we'll get a full fill
-        # including islands. Also set their timestamp to something to identify them later.
+        # Get the allowed area for via placement on all layers (which should include the target areas)
+        allowed_areas = self._get_allowed_areas()
+        
+        # Move target areas back, set them to "No Net" and refill. That way we'll get target placement
+        # areas which include islands.
+        target_areas = self._get_areas_on_copper(self.netname, self.only_selected_area)
+        move_vector = wxPoint(-move_vector.x, -move_vector.y)
         no_net = self.pcb.GetNetsByName()['']
         for areas in target_areas.values():
             for area in areas:
                 area.SetNet(no_net)
-                area.SetTimestamp(34)
+                area.Move(move_vector)
+                area.SetTimeStamp(34)
         self.RefillBoardAreas()
         
-        # Change the net of the target areas to "No Net" and refill. That way we'll get a full fill
-        # including islands
-        for area in target_areas:
-            area.SetNet(self.pcb.GetNetsByName()[''])
-        self.RefillBoardAreas()
-
+        '''
         # Search for areas on top/bottom layers
         all_areas = [self.pcb.GetArea(i) for i in xrange(self.pcb.GetAreaCount())]
         top_areas = filter(lambda x: (x.GetNetname() == '' and x.IsOnLayer(F_Cu) and not x.GetIsKeepout()), all_areas)

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -206,7 +206,7 @@ class BridsonFillStrategy(FillStrategy):
         r = self.centre_spacing + 2
         seed = random.uniform(0, 2 * math.pi)
         for j in range(self.k):
-            th = 2 * math.pi * j / k + seed
+            th = 2 * math.pi * j / self.k + seed
             points.append((int(round(base[0] + r * math.sin(th))), int(round(base[1] + r * math.cos(th)))))
         return points
 

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -358,7 +358,13 @@ class FillArea:
             return
 
         all_areas = [self.pcb.GetArea(i) for i in xrange(self.pcb.GetAreaCount())]
-        target_areas = filter(lambda x: (x.GetNetname() == self.netname and (x.IsOnLayer(F_Cu) or x.IsOnLayer(B_Cu)) and not x.GetIsKeepout()), all_areas)
+        target_predicate = lambda x: (
+            x.GetNetname() == self.netname and
+            (x.IsOnLayer(F_Cu) or x.IsOnLayer(B_Cu)) and
+            not x.GetIsKeepout() and
+            (x.IsSelected() or not self.only_selected_area)
+        )
+        target_areas = filter(target_predicate, all_areas)
 
         # Validate that we don't have any top/bottom no-net layers already. If we do, we can't run this as we'd mess
         # them up when switching the net back.

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -174,7 +174,9 @@ class BridsonFillStrategy(FillStrategy):
             return False
         
         # Check surrounding points
-        for ox_i, oy_i in ((-1, -1), (-1, 0), (-1, 1), (0, 1), (1, 1), (1, 0), (1, -1), (0, -1), (-2, 0), (0, 2), (2, 0), (0, -2)):
+        OFFSETS = ((-1, -1), (-1, 0), (-1, 1), (0, 1), (1, 1), (1, 0), (1, -1), (0, -1),
+                   (-2, -1), (-2, 0), (-2, 1), (-1, 2), (0, 2), (1, 2), (2, 1), (2, 0), (2, -1), (1, -2), (0, -2), (-1, -2))
+        for ox_i, oy_i in :
             px_i = x_i + ox_i
             py_i = y_i + oy_i
             if px_i < 0 or px_i >= self._x_steps or py_i < 0 or py_i >= self._y_steps:

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -176,7 +176,7 @@ class BridsonFillStrategy(FillStrategy):
         # Check surrounding points
         OFFSETS = ((-1, -1), (-1, 0), (-1, 1), (0, 1), (1, 1), (1, 0), (1, -1), (0, -1),
                    (-2, -1), (-2, 0), (-2, 1), (-1, 2), (0, 2), (1, 2), (2, 1), (2, 0), (2, -1), (1, -2), (0, -2), (-1, -2))
-        for ox_i, oy_i in :
+        for ox_i, oy_i in OFFSETS:
             px_i = x_i + ox_i
             py_i = y_i + oy_i
             if px_i < 0 or px_i >= self._x_steps or py_i < 0 or py_i >= self._y_steps:

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -487,7 +487,8 @@ class FillArea:
         for areas in self._get_areas_on_copper('', False, 34).values():
             for area in areas:
                 poly = SHAPE_POLY_SET(area.GetFilledPolysList(), True)
-                poly.Inflate(FromMM(0.2) - int(round(self.clearance + self.size / 2)), 36)
+                poly.Inflate(FromMM(0.2), 36)
+                poly.Inflate(-int(round(self.clearance + self.size / 2)), 36)
                 if allowed is None:
                     allowed = poly
                 else:


### PR DESCRIPTION
There's been a couple of of issues (#23, #31, maybe #29) about the way the via stitching plugin places vias on a grid and handles step and clearance settings.

I ran into these same problems, and so I've started on a bit of a new algorithm for via placement. It goes like this:

- For our target areas, set their net to "no net" and refill them. This way islands are allowed, and the fills will have the correct clearance to all pads, vias, board edges, etc.
- Do a union of all filled target areas on the top layer, and shrink (deflate) them by half our via size
- Do the same for the bottom area
- Union together the top/bottom areas. The resulting area set is the area we can place via centres without the vias being outside a zone, or interfering with traces, pads or anything else.
- Place vias however we want (grid, star, random, etc).

At this point I've only implemented the standard grid pattern, but if there is interest I can do the star pattern, and I was thinking of doing a proper Poisson disc random distribution. For now, at least, here is my WIP.

Oh yeah, the new algorithm seems to be a bit quicker, too.