### PR TITLE
Add support for concentric filling

### DIFF
--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -454,6 +454,10 @@ STEP         = '-'
 
         return via_placed
 
+
+    """
+    Main function which does the via placement or deletion
+    """
     def Run(self):
 
         VIA_GROUP_NAME = "ViaStitching {}".format(self.netname)
@@ -470,10 +474,13 @@ STEP         = '-'
         Launch the process
         """
         if self.delete_vias:
-            # timestmap again available
-            # target_tracks = filter(lambda x: (x.GetNetname().upper() == self.netname), self.pcb.GetTracks())
-            wx.MessageBox(
-                "To delete vias:\n - select one of the generated via to select the group of vias named {}\n - hit delete key\n - That's all !".format(VIA_GROUP_NAME), "Information")
+
+            if self.pcb_group is not None:
+                all_vias = [track for track in self.pcb.GetTracks() if (track.GetClass()=="PCB_VIA" and track.GetNetname()==self.netname)]
+
+                for via in all_vias:
+                    if via.GetParentGroup() is not None and via.GetParentGroup().GetName() == VIA_GROUP_NAME:
+                        via.DeleteStructure()
             return                                          # no need to run the rest of logic
 
         if self.pcb_group is None:

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -429,6 +429,12 @@ STEP         = '-'
         # KeepOuts are filtered because they have no name
         target_areas = filter(lambda x: (x.GetNetname() == self.netname), all_areas)
 
+        # Get the board outline and size with
+        board_edge = SHAPE_POLY_SET()
+        self.pcb.GetBoardPolygonOutlines(board_edge)
+        b_clearance = max(self.pcb.GetDesignSettings().m_CopperEdgeClearance, self.clearance) + self.size
+        board_edge.Deflate(int(b_clearance), int(12),  SHAPE_POLY_SET.ROUND_ALL_CORNERS)
+
         via_list = []       # Create a list of existing vias => faster than scanning through the whole rectangle
         max_target_area_clearance = 0
 
@@ -469,6 +475,8 @@ STEP         = '-'
                             hit_test_edge = area.HitTestForEdge(point_to_test, int(max(area_clearance, offset)))
                             # test_result only remains true if the via is inside an area and not on an edge
                             test_result = (hit_test_area and not hit_test_edge)
+
+                            test_result = (test_result and board_edge.Collide(VECTOR2I(point_to_test))) # check if inside board outline
 
                             if test_result:
                                 # Create a via object with information about the via and place it in the rectangle

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -109,6 +109,7 @@ class FillArea:
     FILL_TYPE_STAR = "Star"
     FILL_TYPE_CONCENTRIC = "Concentric"
     FILL_TYPE_OUTLINE = "Outline"
+    FILL_TYPE_OUTLINE_NO_HOLES = "Outline (No Holes)"
 
     def __init__(self, filename=None):
         self.filename = None
@@ -435,9 +436,10 @@ STEP         = '-'
                 outline = poly_set.Outline(i)
                 via_placed += self.AddViasAlongOutline(outline, all_vias, off)
 
-                for k in range(0, poly_set.HoleCount(i)):
-                    hole = poly_set.Hole(i,k)
-                    via_placed += self.AddViasAlongOutline(hole, all_vias, off)
+                if self.fill_type != self.FILL_TYPE_OUTLINE_NO_HOLES:
+                    for k in range(0, poly_set.HoleCount(i)):
+                        hole = poly_set.Hole(i,k)
+                        via_placed += self.AddViasAlongOutline(hole, all_vias, off)
 
             # Size the polygons to place the next ring
             if self.fill_type == self.FILL_TYPE_CONCENTRIC:
@@ -488,7 +490,7 @@ STEP         = '-'
             self.pcb_group.SetName(VIA_GROUP_NAME)
             self.pcb.Add(self.pcb_group)
 
-        if self.fill_type==self.FILL_TYPE_OUTLINE or self.fill_type==self.FILL_TYPE_CONCENTRIC:
+        if self.fill_type==self.FILL_TYPE_CONCENTRIC or self.fill_type==self.FILL_TYPE_OUTLINE or self.fill_type==self.FILL_TYPE_OUTLINE_NO_HOLES:
             self.ConcentricFillVias()
             if self.filename:
                 self.pcb.Save(self.filename)

--- a/ViaStitching/FillAreaAction.py
+++ b/ViaStitching/FillAreaAction.py
@@ -26,11 +26,9 @@ import os
 
 
 def PopulateNets(anet, dlg):
-    zones = pcbnew.GetBoard().Zones()
-    for zone in zones:
-        netname = zone.GetNetname()
-        if netname is not None and netname != "":
-            dlg.m_cbNet.Append(netname)
+    netnames = list(set([zone.GetNetname() for zone in pcbnew.GetBoard().Zones()]))
+    netnames.sort()
+    dlg.m_cbNet.Set(netnames)
     if anet is not None:
         index = dlg.m_cbNet.FindString(anet)
         dlg.m_cbNet.Select(index)
@@ -59,7 +57,6 @@ class FillAreaAction(pcbnew.ActionPlugin):
         # a.m_DrillMM.SetValue("0.3")
         # a.m_Netname.SetValue("GND")
         # a.m_ClearanceMM.SetValue("0.2")
-        # a.m_Star.SetValue(True)
         a.m_bitmapStitching.SetBitmap(wx.Bitmap(os.path.join(os.path.dirname(os.path.realpath(__file__)), "stitching-vias-help.png")))
         self.board = pcbnew.GetBoard()
         self.boardDesignSettings = self.board.GetDesignSettings()
@@ -84,8 +81,7 @@ class FillAreaAction(pcbnew.ActionPlugin):
                 if a.m_Debug.IsChecked():
                     fill.SetDebug()
                 fill.SetRandom(a.m_Random.IsChecked())
-                if a.m_Star.IsChecked():
-                    fill.SetStar()
+                fill.SetType(a.m_cbFillType.GetStringSelection())
                 if a.m_only_selected.IsChecked():
                     fill.OnlyOnSelectedArea()
                 fill.Run()

--- a/ViaStitching/FillAreaAction.py
+++ b/ViaStitching/FillAreaAction.py
@@ -26,9 +26,9 @@ import os
 
 
 def PopulateNets(anet, dlg):
-    nets = pcbnew.GetBoard().GetNetsByName()
-    for netname, net in nets.items():
-        netname = net.GetNetname()
+    zones = pcbnew.GetBoard().Zones()
+    for zone in zones:
+        netname = zone.GetNetname()
         if netname is not None and netname != "":
             dlg.m_cbNet.Append(netname)
     if anet is not None:

--- a/ViaStitching/FillAreaDialog.py
+++ b/ViaStitching/FillAreaDialog.py
@@ -1,147 +1,151 @@
 # -*- coding: utf-8 -*-
 
 ###########################################################################
-# Python code generated with wxFormBuilder (version 3.9.0 Jul  3 2021)
-# http://www.wxformbuilder.org/
+## Python code generated with wxFormBuilder (version 3.10.1-0-g8feb16b3)
+## http://www.wxformbuilder.org/
 ##
-# PLEASE DO *NOT* EDIT THIS FILE!
+## PLEASE DO *NOT* EDIT THIS FILE!
 ###########################################################################
 
 import wx
 import wx.xrc
 
 ###########################################################################
-# Class FillAreaDialog
+## Class FillAreaDialog
 ###########################################################################
 
+class FillAreaDialog ( wx.Dialog ):
 
-class FillAreaDialog (wx.Dialog):
+	def __init__( self, parent ):
+		wx.Dialog.__init__ ( self, parent, id = wx.ID_ANY, title = u"Fill Area parameters", pos = wx.DefaultPosition, size = wx.Size( 402,580 ), style = wx.DEFAULT_DIALOG_STYLE|wx.RESIZE_BORDER )
 
-    def __init__(self, parent):
-        wx.Dialog.__init__(self, parent, id=wx.ID_ANY, title=u"Fill Area parameters", pos=wx.DefaultPosition,
-                           size=wx.Size(402, 580), style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER)
+		self.SetSizeHints( wx.DefaultSize, wx.DefaultSize )
 
-        self.SetSizeHints(wx.DefaultSize, wx.DefaultSize)
+		bSizer3 = wx.BoxSizer( wx.VERTICAL )
 
-        bSizer3 = wx.BoxSizer(wx.VERTICAL)
+		fgSizer1 = wx.FlexGridSizer( 0, 2, 0, 0 )
+		fgSizer1.SetFlexibleDirection( wx.BOTH )
+		fgSizer1.SetNonFlexibleGrowMode( wx.FLEX_GROWMODE_SPECIFIED )
 
-        fgSizer1 = wx.FlexGridSizer(0, 2, 0, 0)
-        fgSizer1.SetFlexibleDirection(wx.BOTH)
-        fgSizer1.SetNonFlexibleGrowMode(wx.FLEX_GROWMODE_SPECIFIED)
+		self.m_staticText3 = wx.StaticText( self, wx.ID_ANY, u"Via copper size (mm)", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_staticText3.Wrap( -1 )
 
-        self.m_staticText3 = wx.StaticText(self, wx.ID_ANY, u"Via copper size (mm)", wx.DefaultPosition, wx.DefaultSize, 0)
-        self.m_staticText3.Wrap(-1)
+		fgSizer1.Add( self.m_staticText3, 1, wx.ALL|wx.EXPAND, 5 )
 
-        fgSizer1.Add(self.m_staticText3, 1, wx.ALL | wx.EXPAND, 5)
+		self.m_SizeMM = wx.TextCtrl( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_SizeMM.SetMinSize( wx.Size( 1000,-1 ) )
 
-        self.m_SizeMM = wx.TextCtrl(self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0)
-        self.m_SizeMM.SetMinSize(wx.Size(1000, -1))
+		fgSizer1.Add( self.m_SizeMM, 1, wx.ALL|wx.EXPAND, 5 )
 
-        fgSizer1.Add(self.m_SizeMM, 1, wx.ALL | wx.EXPAND, 5)
+		self.m_staticText9 = wx.StaticText( self, wx.ID_ANY, u"Via drill size (mm)", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_staticText9.Wrap( -1 )
 
-        self.m_staticText9 = wx.StaticText(self, wx.ID_ANY, u"Via drill size (mm)", wx.DefaultPosition, wx.DefaultSize, 0)
-        self.m_staticText9.Wrap(-1)
+		fgSizer1.Add( self.m_staticText9, 1, wx.ALL|wx.EXPAND, 5 )
 
-        fgSizer1.Add(self.m_staticText9, 1, wx.ALL | wx.EXPAND, 5)
+		self.m_DrillMM = wx.TextCtrl( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0 )
+		fgSizer1.Add( self.m_DrillMM, 1, wx.ALL|wx.EXPAND, 5 )
 
-        self.m_DrillMM = wx.TextCtrl(self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0)
-        fgSizer1.Add(self.m_DrillMM, 1, wx.ALL | wx.EXPAND, 5)
+		self.m_staticText5 = wx.StaticText( self, wx.ID_ANY, u"Via clearance (mm)", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_staticText5.Wrap( -1 )
 
-        self.m_staticText5 = wx.StaticText(self, wx.ID_ANY, u"Via clearance (mm)", wx.DefaultPosition, wx.DefaultSize, 0)
-        self.m_staticText5.Wrap(-1)
+		fgSizer1.Add( self.m_staticText5, 1, wx.ALL|wx.EXPAND, 5 )
 
-        fgSizer1.Add(self.m_staticText5, 1, wx.ALL | wx.EXPAND, 5)
+		self.m_ClearanceMM = wx.TextCtrl( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0 )
+		fgSizer1.Add( self.m_ClearanceMM, 1, wx.ALL|wx.EXPAND, 5 )
 
-        self.m_ClearanceMM = wx.TextCtrl(self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0)
-        fgSizer1.Add(self.m_ClearanceMM, 1, wx.ALL | wx.EXPAND, 5)
+		self.m_staticText2 = wx.StaticText( self, wx.ID_ANY, u"Via grid (mm)", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_staticText2.Wrap( -1 )
 
-        self.m_staticText2 = wx.StaticText(self, wx.ID_ANY, u"Via grid (mm)", wx.DefaultPosition, wx.DefaultSize, 0)
-        self.m_staticText2.Wrap(-1)
+		fgSizer1.Add( self.m_staticText2, 0, wx.ALL, 5 )
 
-        fgSizer1.Add(self.m_staticText2, 0, wx.ALL, 5)
+		self.m_StepMM = wx.TextCtrl( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0 )
+		fgSizer1.Add( self.m_StepMM, 1, wx.ALL|wx.EXPAND, 5 )
 
-        self.m_StepMM = wx.TextCtrl(self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0)
-        fgSizer1.Add(self.m_StepMM, 1, wx.ALL | wx.EXPAND, 5)
 
-        fgSizer1.Add((0, 0), 1, wx.EXPAND, 5)
+		fgSizer1.Add( ( 0, 0), 1, wx.EXPAND, 5 )
 
-        self.m_bitmapStitching = wx.StaticBitmap(self, wx.ID_ANY, wx.NullBitmap, wx.DefaultPosition, wx.DefaultSize, 0)
-        fgSizer1.Add(self.m_bitmapStitching, 0, wx.EXPAND, 5)
+		self.m_bitmapStitching = wx.StaticBitmap( self, wx.ID_ANY, wx.NullBitmap, wx.DefaultPosition, wx.DefaultSize, 0 )
+		fgSizer1.Add( self.m_bitmapStitching, 0, wx.EXPAND, 5 )
 
-        self.m_staticText6 = wx.StaticText(self, wx.ID_ANY, u"Net name", wx.DefaultPosition, wx.DefaultSize, 0)
-        self.m_staticText6.Wrap(-1)
+		self.m_staticText6 = wx.StaticText( self, wx.ID_ANY, u"Net name", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_staticText6.Wrap( -1 )
 
-        fgSizer1.Add(self.m_staticText6, 1, wx.ALL | wx.EXPAND, 5)
+		fgSizer1.Add( self.m_staticText6, 1, wx.ALL|wx.EXPAND, 5 )
 
-        m_cbNetChoices = []
-        self.m_cbNet = wx.ComboBox(self, wx.ID_ANY, u"GND", wx.DefaultPosition, wx.DefaultSize, m_cbNetChoices, wx.CB_READONLY)
-        fgSizer1.Add(self.m_cbNet, 1, wx.ALL | wx.EXPAND, 5)
+		m_cbNetChoices = []
+		self.m_cbNet = wx.ComboBox( self, wx.ID_ANY, u"GND", wx.DefaultPosition, wx.DefaultSize, m_cbNetChoices, wx.CB_READONLY )
+		fgSizer1.Add( self.m_cbNet, 1, wx.ALL|wx.EXPAND, 5 )
 
-        self.m_staticText7 = wx.StaticText(self, wx.ID_ANY, u"Debug mode", wx.DefaultPosition, wx.DefaultSize, 0)
-        self.m_staticText7.Wrap(-1)
+		self.m_staticText42 = wx.StaticText( self, wx.ID_ANY, u"Star Pattern", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_staticText42.Wrap( -1 )
 
-        fgSizer1.Add(self.m_staticText7, 1, wx.ALL | wx.EXPAND, 5)
+		fgSizer1.Add( self.m_staticText42, 0, wx.ALL, 5 )
 
-        self.m_Debug = wx.CheckBox(self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0)
-        fgSizer1.Add(self.m_Debug, 1, wx.ALL | wx.EXPAND, 5)
+		m_cbFillTypeChoices = [ u"Concentric", u"Outline", u"Rectangular", u"Star" ]
+		self.m_cbFillType = wx.ComboBox( self, wx.ID_ANY, u"Concentric", wx.DefaultPosition, wx.DefaultSize, m_cbFillTypeChoices, wx.CB_READONLY )
+		fgSizer1.Add( self.m_cbFillType, 0, wx.ALL, 5 )
 
-        self.m_staticText8 = wx.StaticText(self, wx.ID_ANY, u"Random it", wx.DefaultPosition, wx.DefaultSize, 0)
-        self.m_staticText8.Wrap(-1)
+		self.m_staticText8 = wx.StaticText( self, wx.ID_ANY, u"Random it", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_staticText8.Wrap( -1 )
 
-        fgSizer1.Add(self.m_staticText8, 0, wx.ALL, 5)
+		fgSizer1.Add( self.m_staticText8, 0, wx.ALL, 5 )
 
-        self.m_Random = wx.CheckBox(self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0)
-        fgSizer1.Add(self.m_Random, 0, wx.ALL, 5)
+		self.m_Random = wx.CheckBox( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0 )
+		fgSizer1.Add( self.m_Random, 0, wx.ALL, 5 )
 
-        self.m_staticText42 = wx.StaticText(self, wx.ID_ANY, u"Star Pattern", wx.DefaultPosition, wx.DefaultSize, 0)
-        self.m_staticText42.Wrap(-1)
+		self.m_staticText81 = wx.StaticText( self, wx.ID_ANY, u"Only under selected Zone", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_staticText81.Wrap( -1 )
 
-        fgSizer1.Add(self.m_staticText42, 0, wx.ALL, 5)
+		fgSizer1.Add( self.m_staticText81, 0, wx.ALL, 5 )
 
-        self.m_Star = wx.CheckBox(self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0)
-        fgSizer1.Add(self.m_Star, 0, wx.ALL, 5)
+		self.m_only_selected = wx.CheckBox( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0 )
+		fgSizer1.Add( self.m_only_selected, 0, wx.ALL, 5 )
 
-        self.m_staticText81 = wx.StaticText(self, wx.ID_ANY, u"Only under selected Zone", wx.DefaultPosition, wx.DefaultSize, 0)
-        self.m_staticText81.Wrap(-1)
+		self.m_staticText7 = wx.StaticText( self, wx.ID_ANY, u"Debug mode", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_staticText7.Wrap( -1 )
 
-        fgSizer1.Add(self.m_staticText81, 0, wx.ALL, 5)
+		fgSizer1.Add( self.m_staticText7, 1, wx.ALL|wx.EXPAND, 5 )
 
-        self.m_only_selected = wx.CheckBox(self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0)
-        fgSizer1.Add(self.m_only_selected, 0, wx.ALL, 5)
+		self.m_Debug = wx.CheckBox( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0 )
+		fgSizer1.Add( self.m_Debug, 1, wx.ALL|wx.EXPAND, 5 )
 
-        bSizer3.Add(fgSizer1, 1, wx.EXPAND, 5)
 
-        bSizer1 = wx.BoxSizer(wx.HORIZONTAL)
+		bSizer3.Add( fgSizer1, 1, wx.EXPAND, 5 )
 
-        self.m_staticText101 = wx.StaticText(self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0)
-        self.m_staticText101.Wrap(-1)
+		bSizer1 = wx.BoxSizer( wx.HORIZONTAL )
 
-        bSizer1.Add(self.m_staticText101, 1, wx.ALL, 5)
+		self.m_staticText101 = wx.StaticText( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_staticText101.Wrap( -1 )
 
-        self.m_button1 = wx.Button(self, wx.ID_OK, u"Run", wx.DefaultPosition, wx.DefaultSize, 0)
+		bSizer1.Add( self.m_staticText101, 1, wx.ALL, 5 )
 
-        self.m_button1.SetDefault()
-        bSizer1.Add(self.m_button1, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+		self.m_button1 = wx.Button( self, wx.ID_OK, u"Run", wx.DefaultPosition, wx.DefaultSize, 0 )
 
-        self.m_button2 = wx.Button(self, wx.ID_CANCEL, u"Cancel", wx.DefaultPosition, wx.DefaultSize, 0)
-        bSizer1.Add(self.m_button2, 0, wx.ALL, 5)
+		self.m_button1.SetDefault()
+		bSizer1.Add( self.m_button1, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 5 )
 
-        self.m_button3_delete = wx.Button(self, wx.ID_DELETE, u"Delete Vias", wx.DefaultPosition, wx.DefaultSize, 0)
-        bSizer1.Add(self.m_button3_delete, 0, wx.ALL, 5)
+		self.m_button2 = wx.Button( self, wx.ID_CANCEL, u"Cancel", wx.DefaultPosition, wx.DefaultSize, 0 )
+		bSizer1.Add( self.m_button2, 0, wx.ALL, 5 )
 
-        bSizer3.Add(bSizer1, 0, wx.EXPAND | wx.ALIGN_RIGHT, 5)
+		self.m_button3_delete = wx.Button( self, wx.ID_DELETE, u"Delete Vias", wx.DefaultPosition, wx.DefaultSize, 0 )
+		bSizer1.Add( self.m_button3_delete, 0, wx.ALL, 5 )
 
-        self.SetSizer(bSizer3)
-        self.Layout()
 
-        self.Centre(wx.BOTH)
+		bSizer3.Add( bSizer1, 0, wx.EXPAND|wx.ALIGN_RIGHT, 5 )
 
-        # Connect Events
-        self.m_button3_delete.Bind(wx.EVT_BUTTON, self.onDeleteClick)
 
-    def __del__(self):
-        pass
+		self.SetSizer( bSizer3 )
+		self.Layout()
 
-    # Virtual event handlers, override them in your derived class
-    def onDeleteClick(self, event):
-        event.Skip()
+		self.Centre( wx.BOTH )
+
+		# Connect Events
+		self.m_button3_delete.Bind( wx.EVT_BUTTON, self.onDeleteClick )
+
+	def __del__( self ):
+		pass
+
+
+	# Virtual event handlers, override them in your derived class
+	def onDeleteClick( self, event ):
+		event.Skip()

--- a/ViaStitching/FillAreaDialog.py
+++ b/ViaStitching/FillAreaDialog.py
@@ -81,7 +81,7 @@ class FillAreaDialog ( wx.Dialog ):
 
 		fgSizer1.Add( self.m_staticText42, 0, wx.ALL, 5 )
 
-		m_cbFillTypeChoices = [ u"Concentric", u"Outline", u"Rectangular", u"Star" ]
+		m_cbFillTypeChoices = [ u"Concentric", u"Outline", u"Outline (No Holes)", u"Rectangular", u"Star" ]
 		self.m_cbFillType = wx.ComboBox( self, wx.ID_ANY, u"Concentric", wx.DefaultPosition, wx.DefaultSize, m_cbFillTypeChoices, wx.CB_READONLY )
 		fgSizer1.Add( self.m_cbFillType, 0, wx.ALL, 5 )
 

--- a/ViaStitching/FillAreaDialog.py
+++ b/ViaStitching/FillAreaDialog.py
@@ -17,7 +17,7 @@ import wx.xrc
 class FillAreaDialog ( wx.Dialog ):
 
 	def __init__( self, parent ):
-		wx.Dialog.__init__ ( self, parent, id = wx.ID_ANY, title = u"Fill Area parameters", pos = wx.DefaultPosition, size = wx.Size( 402,580 ), style = wx.DEFAULT_DIALOG_STYLE|wx.RESIZE_BORDER )
+		wx.Dialog.__init__ ( self, parent, id = wx.ID_ANY, title = u"Fill Area parameters", pos = wx.DefaultPosition, size = wx.Size( 402,590 ), style = wx.DEFAULT_DIALOG_STYLE|wx.RESIZE_BORDER )
 
 		self.SetSizeHints( wx.DefaultSize, wx.DefaultSize )
 

--- a/ViaStitching/FillAreaTpl.fbp
+++ b/ViaStitching/FillAreaTpl.fbp
@@ -47,7 +47,7 @@
             <property name="minimum_size"></property>
             <property name="name">FillAreaDialog</property>
             <property name="pos"></property>
-            <property name="size">402,580</property>
+            <property name="size">402,590</property>
             <property name="style">wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER</property>
             <property name="subclass"></property>
             <property name="title">Fill Area parameters</property>

--- a/ViaStitching/FillAreaTpl.fbp
+++ b/ViaStitching/FillAreaTpl.fbp
@@ -850,7 +850,7 @@
                                 <property name="caption"></property>
                                 <property name="caption_visible">1</property>
                                 <property name="center_pane">0</property>
-                                <property name="choices">&quot;Concentric&quot; &quot;Outline&quot; &quot;Rectangular&quot; &quot;Star&quot;</property>
+                                <property name="choices">&quot;Concentric&quot; &quot;Outline&quot; &quot;Outline (No Holes)&quot; &quot;Rectangular&quot; &quot;Star&quot;</property>
                                 <property name="close_button">1</property>
                                 <property name="context_help"></property>
                                 <property name="context_menu">1</property>

--- a/ViaStitching/FillAreaTpl.fbp
+++ b/ViaStitching/FillAreaTpl.fbp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <wxFormBuilder_Project>
-    <FileVersion major="1" minor="15" />
+    <FileVersion major="1" minor="16" />
     <object class="Project" expanded="1">
         <property name="class_decoration"></property>
         <property name="code_generation">Python</property>
@@ -14,6 +14,7 @@
         <property name="file">FillAreaDialog</property>
         <property name="first_id">1000</property>
         <property name="help_provider">none</property>
+        <property name="image_path_wrapper_function_name"></property>
         <property name="indent_with_spaces"></property>
         <property name="internationalize">0</property>
         <property name="name">FillAreaDialog</property>
@@ -25,6 +26,7 @@
         <property name="skip_php_events">1</property>
         <property name="skip_python_events">1</property>
         <property name="ui_table">UI</property>
+        <property name="use_array_enum">0</property>
         <property name="use_enum">0</property>
         <property name="use_microsoft_bom">0</property>
         <object class="Dialog" expanded="1">
@@ -50,6 +52,7 @@
             <property name="subclass"></property>
             <property name="title">Fill Area parameters</property>
             <property name="tooltip"></property>
+            <property name="two_step_creation">0</property>
             <property name="window_extra_style"></property>
             <property name="window_name"></property>
             <property name="window_style"></property>
@@ -768,11 +771,11 @@
                                 <property name="window_style"></property>
                             </object>
                         </object>
-                        <object class="sizeritem" expanded="0">
+                        <object class="sizeritem" expanded="1">
                             <property name="border">5</property>
-                            <property name="flag">wxALL|wxEXPAND</property>
-                            <property name="proportion">1</property>
-                            <object class="wxStaticText" expanded="0">
+                            <property name="flag">wxALL</property>
+                            <property name="proportion">0</property>
+                            <object class="wxStaticText" expanded="1">
                                 <property name="BottomDockable">1</property>
                                 <property name="LeftDockable">1</property>
                                 <property name="RightDockable">1</property>
@@ -800,7 +803,7 @@
                                 <property name="gripper">0</property>
                                 <property name="hidden">0</property>
                                 <property name="id">wxID_ANY</property>
-                                <property name="label">Debug mode</property>
+                                <property name="label">Star Pattern</property>
                                 <property name="markup">0</property>
                                 <property name="max_size"></property>
                                 <property name="maximize_button">0</property>
@@ -809,7 +812,7 @@
                                 <property name="minimize_button">0</property>
                                 <property name="minimum_size"></property>
                                 <property name="moveable">1</property>
-                                <property name="name">m_staticText7</property>
+                                <property name="name">m_staticText42</property>
                                 <property name="pane_border">1</property>
                                 <property name="pane_position"></property>
                                 <property name="pane_size"></property>
@@ -829,11 +832,11 @@
                                 <property name="wrap">-1</property>
                             </object>
                         </object>
-                        <object class="sizeritem" expanded="0">
+                        <object class="sizeritem" expanded="1">
                             <property name="border">5</property>
-                            <property name="flag">wxALL|wxEXPAND</property>
-                            <property name="proportion">1</property>
-                            <object class="wxCheckBox" expanded="0">
+                            <property name="flag">wxALL</property>
+                            <property name="proportion">0</property>
+                            <object class="wxComboBox" expanded="1">
                                 <property name="BottomDockable">1</property>
                                 <property name="LeftDockable">1</property>
                                 <property name="RightDockable">1</property>
@@ -847,7 +850,7 @@
                                 <property name="caption"></property>
                                 <property name="caption_visible">1</property>
                                 <property name="center_pane">0</property>
-                                <property name="checked">0</property>
+                                <property name="choices">&quot;Concentric&quot; &quot;Outline&quot; &quot;Rectangular&quot; &quot;Star&quot;</property>
                                 <property name="close_button">1</property>
                                 <property name="context_help"></property>
                                 <property name="context_menu">1</property>
@@ -862,7 +865,6 @@
                                 <property name="gripper">0</property>
                                 <property name="hidden">0</property>
                                 <property name="id">wxID_ANY</property>
-                                <property name="label"></property>
                                 <property name="max_size"></property>
                                 <property name="maximize_button">0</property>
                                 <property name="maximum_size"></property>
@@ -870,7 +872,7 @@
                                 <property name="minimize_button">0</property>
                                 <property name="minimum_size"></property>
                                 <property name="moveable">1</property>
-                                <property name="name">m_Debug</property>
+                                <property name="name">m_cbFillType</property>
                                 <property name="pane_border">1</property>
                                 <property name="pane_position"></property>
                                 <property name="pane_size"></property>
@@ -878,9 +880,10 @@
                                 <property name="pin_button">1</property>
                                 <property name="pos"></property>
                                 <property name="resize">Resizable</property>
+                                <property name="selection">-1</property>
                                 <property name="show">1</property>
                                 <property name="size"></property>
-                                <property name="style"></property>
+                                <property name="style">wxCB_READONLY</property>
                                 <property name="subclass"></property>
                                 <property name="toolbar_pane">0</property>
                                 <property name="tooltip"></property>
@@ -888,6 +891,7 @@
                                 <property name="validator_style">wxFILTER_NONE</property>
                                 <property name="validator_type">wxDefaultValidator</property>
                                 <property name="validator_variable"></property>
+                                <property name="value">Concentric</property>
                                 <property name="window_extra_style"></property>
                                 <property name="window_name"></property>
                                 <property name="window_style"></property>
@@ -996,131 +1000,6 @@
                                 <property name="minimum_size"></property>
                                 <property name="moveable">1</property>
                                 <property name="name">m_Random</property>
-                                <property name="pane_border">1</property>
-                                <property name="pane_position"></property>
-                                <property name="pane_size"></property>
-                                <property name="permission">protected</property>
-                                <property name="pin_button">1</property>
-                                <property name="pos"></property>
-                                <property name="resize">Resizable</property>
-                                <property name="show">1</property>
-                                <property name="size"></property>
-                                <property name="style"></property>
-                                <property name="subclass"></property>
-                                <property name="toolbar_pane">0</property>
-                                <property name="tooltip"></property>
-                                <property name="validator_data_type"></property>
-                                <property name="validator_style">wxFILTER_NONE</property>
-                                <property name="validator_type">wxDefaultValidator</property>
-                                <property name="validator_variable"></property>
-                                <property name="window_extra_style"></property>
-                                <property name="window_name"></property>
-                                <property name="window_style"></property>
-                            </object>
-                        </object>
-                        <object class="sizeritem" expanded="1">
-                            <property name="border">5</property>
-                            <property name="flag">wxALL</property>
-                            <property name="proportion">0</property>
-                            <object class="wxStaticText" expanded="1">
-                                <property name="BottomDockable">1</property>
-                                <property name="LeftDockable">1</property>
-                                <property name="RightDockable">1</property>
-                                <property name="TopDockable">1</property>
-                                <property name="aui_layer"></property>
-                                <property name="aui_name"></property>
-                                <property name="aui_position"></property>
-                                <property name="aui_row"></property>
-                                <property name="best_size"></property>
-                                <property name="bg"></property>
-                                <property name="caption"></property>
-                                <property name="caption_visible">1</property>
-                                <property name="center_pane">0</property>
-                                <property name="close_button">1</property>
-                                <property name="context_help"></property>
-                                <property name="context_menu">1</property>
-                                <property name="default_pane">0</property>
-                                <property name="dock">Dock</property>
-                                <property name="dock_fixed">0</property>
-                                <property name="docking">Left</property>
-                                <property name="enabled">1</property>
-                                <property name="fg"></property>
-                                <property name="floatable">1</property>
-                                <property name="font"></property>
-                                <property name="gripper">0</property>
-                                <property name="hidden">0</property>
-                                <property name="id">wxID_ANY</property>
-                                <property name="label">Star Pattern</property>
-                                <property name="markup">0</property>
-                                <property name="max_size"></property>
-                                <property name="maximize_button">0</property>
-                                <property name="maximum_size"></property>
-                                <property name="min_size"></property>
-                                <property name="minimize_button">0</property>
-                                <property name="minimum_size"></property>
-                                <property name="moveable">1</property>
-                                <property name="name">m_staticText42</property>
-                                <property name="pane_border">1</property>
-                                <property name="pane_position"></property>
-                                <property name="pane_size"></property>
-                                <property name="permission">protected</property>
-                                <property name="pin_button">1</property>
-                                <property name="pos"></property>
-                                <property name="resize">Resizable</property>
-                                <property name="show">1</property>
-                                <property name="size"></property>
-                                <property name="style"></property>
-                                <property name="subclass"></property>
-                                <property name="toolbar_pane">0</property>
-                                <property name="tooltip"></property>
-                                <property name="window_extra_style"></property>
-                                <property name="window_name"></property>
-                                <property name="window_style"></property>
-                                <property name="wrap">-1</property>
-                            </object>
-                        </object>
-                        <object class="sizeritem" expanded="1">
-                            <property name="border">5</property>
-                            <property name="flag">wxALL</property>
-                            <property name="proportion">0</property>
-                            <object class="wxCheckBox" expanded="1">
-                                <property name="BottomDockable">1</property>
-                                <property name="LeftDockable">1</property>
-                                <property name="RightDockable">1</property>
-                                <property name="TopDockable">1</property>
-                                <property name="aui_layer"></property>
-                                <property name="aui_name"></property>
-                                <property name="aui_position"></property>
-                                <property name="aui_row"></property>
-                                <property name="best_size"></property>
-                                <property name="bg"></property>
-                                <property name="caption"></property>
-                                <property name="caption_visible">1</property>
-                                <property name="center_pane">0</property>
-                                <property name="checked">0</property>
-                                <property name="close_button">1</property>
-                                <property name="context_help"></property>
-                                <property name="context_menu">1</property>
-                                <property name="default_pane">0</property>
-                                <property name="dock">Dock</property>
-                                <property name="dock_fixed">0</property>
-                                <property name="docking">Left</property>
-                                <property name="enabled">1</property>
-                                <property name="fg"></property>
-                                <property name="floatable">1</property>
-                                <property name="font"></property>
-                                <property name="gripper">0</property>
-                                <property name="hidden">0</property>
-                                <property name="id">wxID_ANY</property>
-                                <property name="label"></property>
-                                <property name="max_size"></property>
-                                <property name="maximize_button">0</property>
-                                <property name="maximum_size"></property>
-                                <property name="min_size"></property>
-                                <property name="minimize_button">0</property>
-                                <property name="minimum_size"></property>
-                                <property name="moveable">1</property>
-                                <property name="name">m_Star</property>
                                 <property name="pane_border">1</property>
                                 <property name="pane_position"></property>
                                 <property name="pane_size"></property>
@@ -1268,6 +1147,131 @@
                                 <property name="window_style"></property>
                             </object>
                         </object>
+                        <object class="sizeritem" expanded="0">
+                            <property name="border">5</property>
+                            <property name="flag">wxALL|wxEXPAND</property>
+                            <property name="proportion">1</property>
+                            <object class="wxStaticText" expanded="0">
+                                <property name="BottomDockable">1</property>
+                                <property name="LeftDockable">1</property>
+                                <property name="RightDockable">1</property>
+                                <property name="TopDockable">1</property>
+                                <property name="aui_layer"></property>
+                                <property name="aui_name"></property>
+                                <property name="aui_position"></property>
+                                <property name="aui_row"></property>
+                                <property name="best_size"></property>
+                                <property name="bg"></property>
+                                <property name="caption"></property>
+                                <property name="caption_visible">1</property>
+                                <property name="center_pane">0</property>
+                                <property name="close_button">1</property>
+                                <property name="context_help"></property>
+                                <property name="context_menu">1</property>
+                                <property name="default_pane">0</property>
+                                <property name="dock">Dock</property>
+                                <property name="dock_fixed">0</property>
+                                <property name="docking">Left</property>
+                                <property name="enabled">1</property>
+                                <property name="fg"></property>
+                                <property name="floatable">1</property>
+                                <property name="font"></property>
+                                <property name="gripper">0</property>
+                                <property name="hidden">0</property>
+                                <property name="id">wxID_ANY</property>
+                                <property name="label">Debug mode</property>
+                                <property name="markup">0</property>
+                                <property name="max_size"></property>
+                                <property name="maximize_button">0</property>
+                                <property name="maximum_size"></property>
+                                <property name="min_size"></property>
+                                <property name="minimize_button">0</property>
+                                <property name="minimum_size"></property>
+                                <property name="moveable">1</property>
+                                <property name="name">m_staticText7</property>
+                                <property name="pane_border">1</property>
+                                <property name="pane_position"></property>
+                                <property name="pane_size"></property>
+                                <property name="permission">protected</property>
+                                <property name="pin_button">1</property>
+                                <property name="pos"></property>
+                                <property name="resize">Resizable</property>
+                                <property name="show">1</property>
+                                <property name="size"></property>
+                                <property name="style"></property>
+                                <property name="subclass"></property>
+                                <property name="toolbar_pane">0</property>
+                                <property name="tooltip"></property>
+                                <property name="window_extra_style"></property>
+                                <property name="window_name"></property>
+                                <property name="window_style"></property>
+                                <property name="wrap">-1</property>
+                            </object>
+                        </object>
+                        <object class="sizeritem" expanded="0">
+                            <property name="border">5</property>
+                            <property name="flag">wxALL|wxEXPAND</property>
+                            <property name="proportion">1</property>
+                            <object class="wxCheckBox" expanded="0">
+                                <property name="BottomDockable">1</property>
+                                <property name="LeftDockable">1</property>
+                                <property name="RightDockable">1</property>
+                                <property name="TopDockable">1</property>
+                                <property name="aui_layer"></property>
+                                <property name="aui_name"></property>
+                                <property name="aui_position"></property>
+                                <property name="aui_row"></property>
+                                <property name="best_size"></property>
+                                <property name="bg"></property>
+                                <property name="caption"></property>
+                                <property name="caption_visible">1</property>
+                                <property name="center_pane">0</property>
+                                <property name="checked">0</property>
+                                <property name="close_button">1</property>
+                                <property name="context_help"></property>
+                                <property name="context_menu">1</property>
+                                <property name="default_pane">0</property>
+                                <property name="dock">Dock</property>
+                                <property name="dock_fixed">0</property>
+                                <property name="docking">Left</property>
+                                <property name="enabled">1</property>
+                                <property name="fg"></property>
+                                <property name="floatable">1</property>
+                                <property name="font"></property>
+                                <property name="gripper">0</property>
+                                <property name="hidden">0</property>
+                                <property name="id">wxID_ANY</property>
+                                <property name="label"></property>
+                                <property name="max_size"></property>
+                                <property name="maximize_button">0</property>
+                                <property name="maximum_size"></property>
+                                <property name="min_size"></property>
+                                <property name="minimize_button">0</property>
+                                <property name="minimum_size"></property>
+                                <property name="moveable">1</property>
+                                <property name="name">m_Debug</property>
+                                <property name="pane_border">1</property>
+                                <property name="pane_position"></property>
+                                <property name="pane_size"></property>
+                                <property name="permission">protected</property>
+                                <property name="pin_button">1</property>
+                                <property name="pos"></property>
+                                <property name="resize">Resizable</property>
+                                <property name="show">1</property>
+                                <property name="size"></property>
+                                <property name="style"></property>
+                                <property name="subclass"></property>
+                                <property name="toolbar_pane">0</property>
+                                <property name="tooltip"></property>
+                                <property name="validator_data_type"></property>
+                                <property name="validator_style">wxFILTER_NONE</property>
+                                <property name="validator_type">wxDefaultValidator</property>
+                                <property name="validator_variable"></property>
+                                <property name="window_extra_style"></property>
+                                <property name="window_name"></property>
+                                <property name="window_style"></property>
+                            </object>
+                        </object>
                     </object>
                 </object>
                 <object class="sizeritem" expanded="1">
@@ -1353,6 +1357,7 @@
                                 <property name="aui_name"></property>
                                 <property name="aui_position"></property>
                                 <property name="aui_row"></property>
+                                <property name="auth_needed">0</property>
                                 <property name="best_size"></property>
                                 <property name="bg"></property>
                                 <property name="bitmap"></property>
@@ -1425,6 +1430,7 @@
                                 <property name="aui_name"></property>
                                 <property name="aui_position"></property>
                                 <property name="aui_row"></property>
+                                <property name="auth_needed">0</property>
                                 <property name="best_size"></property>
                                 <property name="bg"></property>
                                 <property name="bitmap"></property>
@@ -1497,6 +1503,7 @@
                                 <property name="aui_name"></property>
                                 <property name="aui_position"></property>
                                 <property name="aui_row"></property>
+                                <property name="auth_needed">0</property>
                                 <property name="best_size"></property>
                                 <property name="bg"></property>
                                 <property name="bitmap"></property>


### PR DESCRIPTION
Added support for concentric filling: The vias will be aligned with the edges of the areas.
There are option to entirely fill overlapping areas with vias, to only add an outer ring or to only add an outer ring to the outside (so not along holes).

In addition the delete vias function is implemented.

Full area fill ("Concentric"):
<img width="701" alt="image" src="https://user-images.githubusercontent.com/43108771/175817359-df02db76-4f60-4b19-ab2d-4325c5aa5c36.png">

Along edges both outside and inside ("Outline"):
<img width="721" alt="image" src="https://user-images.githubusercontent.com/43108771/175817409-1186454e-5dee-49ed-bbf8-bf7a0821aba2.png">

Along edge outside edge only ("Outline (No Holes)"):
<img width="724" alt="image" src="https://user-images.githubusercontent.com/43108771/175817460-24a2cd0f-4b64-49c4-8e6b-a789dcb41e57.png">

And for reference the original modes:

Rectangular ("Rectangular"):
<img width="724" alt="image" src="https://user-images.githubusercontent.com/43108771/175817575-9b40cbc7-aca8-457a-8819-d60eaefcfc57.png">

Random rectangular ("Rectangular", with random switch):
<img width="728" alt="image" src="https://user-images.githubusercontent.com/43108771/175817619-4991da21-d6ad-4a39-9ecf-453f4d936b45.png">

Star ("Star"):
<img width="726" alt="image" src="https://user-images.githubusercontent.com/43108771/175817644-bc78c8d1-e1cf-43da-b60f-2e692a98b426.png">

Random star ("Star", with random switch):
<img width="721" alt="image" src="https://user-images.githubusercontent.com/43108771/175817711-4586d5de-f4a3-48bc-9e2a-05ee178a4d52.png">

