### PR TITLE
Fix random offset bound (Issue #56)

### DIFF
--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -764,8 +764,9 @@ STEP         = '-'
                     ran_y = 0
 
                     if self.random:
-                        ran_x = (random.random() * l_clearance / 2.0) - (l_clearance / 4.0)
-                        ran_y = (random.random() * l_clearance / 2.0) - (l_clearance / 4.0)
+                        max_offset = max(self.step - (self.clearance + self.size), 0) / 2.0
+                        ran_x = (random.random() * max_offset) - (max_offset / 2.0)
+                        ran_y = (random.random() * max_offset) - (max_offset / 2.0)
 
                     self.AddVia(wxPoint(via.PosX + ran_x, via.PosY + ran_y), via.X, via.Y)
                     via_placed += 1


### PR DESCRIPTION
This PR fixes #56 : the maximal safe distance a via can ever be moved around without risking to bump into another via (including its clearance) is geometrically:
```python
(self.step - (self.clearance + self.size)) / 2
```
This might be negative if the step size is very small, hence the max with 0.