### PR TITLE
fix: pass aLayer arg to PAD.GetEffectivePolygon

### DIFF
--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -696,7 +696,7 @@ STEP         = '-'
                                 m.SetViaType(VIATYPE_THROUGH)
                                 m.SetDrill(int(self.drill))
                                 m.SetWidth(int(self.size))
-                                if pad.GetEffectivePolygon().Collide(m.GetEffectiveShape()):
+                                if pad.GetEffectivePolygon(pad.GetLayer()).Collide(m.GetEffectiveShape()):
                                     rectangle[x][y] = self.REASON_PAD
 
                     except:


### PR DESCRIPTION
`pcbnew.PAD.GetEffectivePolygon` now requires a `PCB_LAYER_ID aLayer` arg in KiCad 9.0 otherwise vias land on pads

https://docs.kicad.org/doxygen-python-9.0/classpcbnew_1_1PAD.html#a77a5d47479613349743e56a69676c404