### PR TITLE
Don't pass SHAPE_POLY_SET.PM_FAST as a 2nd parameter into poly_set operations

### DIFF
--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -452,8 +452,8 @@ STEP         = '-'
             if poly_set is None:
                 poly_set = poly_set_layer
             else:
-                poly_set.BooleanIntersection(poly_set_layer, SHAPE_POLY_SET.PM_FAST)
-                poly_set.Simplify(SHAPE_POLY_SET.PM_FAST)
+                poly_set.BooleanIntersection(poly_set_layer)
+                poly_set.Simplify()
 
             if poly_set.OutlineCount() == 0:
                 wxPrint("No areas to fill")


### PR DESCRIPTION
This is a fix for issue #84.

I'm unsure if this is a complete fix, but with this applied I no longer get errors on concentric, star and outline modes on Kicad 9.0.5