### PR TITLE
Fix #80: Add Keep-Out Zone Support (Board & Footprint Level)

### DIFF
--- a/ViaStitching/keepout_checker.py
+++ b/ViaStitching/keepout_checker.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python
+"""
+Keep-Out Zone Checker for KiCad ViaStitching Plugins
+Compatible with KiCad 9.0.x
+
+This module provides functions to check if a via position is allowed
+by respecting keep-out zones at both board and footprint level.
+
+Usage:
+    from keepout_checker import KeepOutChecker
+    
+    # Initialize once per fill operation
+    checker = KeepOutChecker(board)
+    
+    # Check each via position
+    if checker.is_via_allowed(position, via_size):
+        # Place via
+        pass
+
+Author: Keep-Out Zone Enhancement 2025 by MrDix
+License: GPL v3
+"""
+
+import pcbnew
+import math
+
+
+class KeepOutChecker:
+    """
+    Efficient keep-out zone checker for via placement.
+    Caches keep-out zones for performance.
+    """
+    
+    def __init__(self, board, debug=False):
+        """
+        Initialize the checker and cache all keep-out zones.
+        
+        Args:
+            board: KiCad BOARD object
+            debug: Enable debug output
+        """
+        self.board = board
+        self.debug = debug
+        self.keepout_zones = self._collect_keepout_zones()
+        
+        if self.debug and len(self.keepout_zones) > 0:
+            print(f"[KeepOutChecker] Found {len(self.keepout_zones)} keep-out zone(s)")
+    
+    def _collect_keepout_zones(self):
+        """
+        Collect all keep-out zones that prohibit vias.
+        
+        Returns:
+            List of ZONE objects that are keep-out zones prohibiting vias
+        """
+        zones = []
+        
+        try:
+            # 1. Board-level keep-out zones
+            for i in range(self.board.GetAreaCount()):
+                zone = self.board.GetArea(i)
+                
+                if zone.GetIsRuleArea() and zone.GetDoNotAllowVias():
+                    zones.append(zone)
+                    if self.debug:
+                        print(f"[KeepOutChecker] Added board keep-out zone {i}")
+            
+            # 2. Footprint-level keep-out zones
+            # API compatibility for both older and newer KiCad versions
+            if hasattr(self.board, 'GetModules'):
+                footprints = self.board.GetModules()
+            else:
+                footprints = self.board.GetFootprints()
+            
+            for footprint in footprints:
+                for zone in footprint.Zones():
+                    if zone.GetIsRuleArea() and zone.GetDoNotAllowVias():
+                        zones.append(zone)
+                        if self.debug:
+                            print(f"[KeepOutChecker] Added footprint keep-out zone")
+        
+        except Exception as e:
+            if self.debug:
+                print(f"[KeepOutChecker] Error collecting zones: {e}")
+        
+        return zones
+    
+    def _is_point_in_zone(self, zone, point):
+        """
+        Check if a point is inside a zone using KiCad 9.0 API.
+        
+        Args:
+            zone: ZONE object
+            point: VECTOR2I point to test
+            
+        Returns:
+            True if point is in zone, False otherwise
+        """
+        try:
+            # Ensure point is VECTOR2I
+            if not isinstance(point, pcbnew.VECTOR2I):
+                point = pcbnew.VECTOR2I(int(point.x), int(point.y))
+            
+            # Get zone layers
+            layer_set = zone.GetLayerSet()
+            
+            # Test on all layers the zone covers
+            for layer_id in range(pcbnew.PCBNEW_LAYER_ID_START, 
+                                 pcbnew.PCBNEW_LAYER_ID_START + pcbnew.PCB_LAYER_ID_COUNT):
+                if layer_set.Contains(layer_id):
+                    # KiCad 9.0 API: HitTestFilledArea(layer, VECTOR2I)
+                    if zone.HitTestFilledArea(layer_id, point):
+                        return True
+            
+            return False
+            
+        except Exception as e:
+            if self.debug:
+                print(f"[KeepOutChecker] Error in point test: {e}")
+            return False
+    
+    def is_via_allowed(self, position, via_size, check_edges=True):
+        """
+        Check if a via can be placed at the given position.
+        
+        Args:
+            position: VECTOR2I or compatible position
+            via_size: Via diameter in nanometers
+            check_edges: If True, also check points around via edge
+            
+        Returns:
+            True if via is allowed, False if it would violate a keep-out zone
+        """
+        # No keep-out zones = all positions allowed
+        if len(self.keepout_zones) == 0:
+            return True
+        
+        try:
+            # Ensure position is VECTOR2I
+            if not isinstance(position, pcbnew.VECTOR2I):
+                position = pcbnew.VECTOR2I(int(position.x), int(position.y))
+            
+            # Check center point
+            for zone in self.keepout_zones:
+                if self._is_point_in_zone(zone, position):
+                    return False
+            
+            # Optionally check edge points
+            if check_edges and via_size > 0:
+                via_radius = via_size // 2
+                
+                # Check 8 points around the via edge
+                for angle_deg in [0, 45, 90, 135, 180, 225, 270, 315]:
+                    angle_rad = math.radians(angle_deg)
+                    edge_x = int(position.x + via_radius * math.cos(angle_rad))
+                    edge_y = int(position.y + via_radius * math.sin(angle_rad))
+                    edge_point = pcbnew.VECTOR2I(edge_x, edge_y)
+                    
+                    for zone in self.keepout_zones:
+                        if self._is_point_in_zone(zone, edge_point):
+                            return False
+            
+            # All checks passed
+            return True
+            
+        except Exception as e:
+            if self.debug:
+                print(f"[KeepOutChecker] Error checking position: {e}")
+            # Fail-safe: allow placement if error occurs
+            return True
+    
+    def get_zone_count(self):
+        """Get the number of keep-out zones found."""
+        return len(self.keepout_zones)
+
+
+# Standalone function for simple usage
+def is_via_allowed_at_position(board, position, via_size, cached_checker=None, debug=False):
+    """
+    Simple function to check if a via is allowed at a position.
+    
+    Args:
+        board: KiCad BOARD object
+        position: VECTOR2I position
+        via_size: Via diameter in nanometers
+        cached_checker: Optional pre-initialized KeepOutChecker for performance
+        debug: Enable debug output
+        
+    Returns:
+        True if via is allowed, False otherwise
+    """
+    if cached_checker is None:
+        cached_checker = KeepOutChecker(board, debug=debug)
+    
+    return cached_checker.is_via_allowed(position, via_size)
+
+
+# Example usage
+if __name__ == "__main__":
+    print("Keep-Out Zone Checker Module for KiCad ViaStitching")
+    print("=" * 50)
+    print()
+    print("Usage in your plugin:")
+    print()
+    print("from keepout_checker import KeepOutChecker")
+    print()
+    print("# Initialize once")
+    print("checker = KeepOutChecker(board, debug=True)")
+    print()
+    print("# Check each position")
+    print("for position in via_positions:")
+    print("    if checker.is_via_allowed(position, via_size):")
+    print("        # Place via")
+    print("        pass")


### PR DESCRIPTION
## Summary

This PR adds support for keep-out zones to the ViaStitching plugin, addressing issue #80.

The plugin now respects:
- ✅ Board-level keep-out zones (rule areas with "Do not allow vias")
- ✅ Footprint-level keep-out zones
- ✅ Accurate edge detection (tests 8 points around via perimeter)

## Motivation

Currently, the ViaStitching plugin ignores keep-out zones, which can result in:
- DRC violations
- Manual cleanup of incorrectly placed vias
- Inability to use automated via stitching near sensitive areas

Related issue: #80

## Changes

### Files Modified
- `ViaStitching/FillArea.py` - Added keep-out zone checking before via placement

### Files Added
- `ViaStitching/keepout_checker.py` - Standalone module for keep-out zone detection

### Implementation Details

1. **Minimal invasive approach**: Only 3 code blocks added to `FillArea.py`
2. **Performance optimized**: Keep-out zones are cached once per run
3. **API compatible**: Uses KiCad 9.0.x VECTOR2I-based API
4. **Backwards compatible**: Plugin works normally if no keep-out zones are present

## Testing

Tested on:
- **KiCad Version:** 9.0.5
- **Platform:** Windows 11
- **Test cases:**
  - ✅ Board-level keep-out zones
  - ✅ Footprint-level keep-out zones
  - ✅ Multiple keep-out zones simultaneously
  - ✅ Different via sizes
  - ✅ Rectangular and other pattern types
  - ✅ Performance with large boards

## Example Usage

**Console output with keep-out zones:**
```
Via Stitching: Version 1.5
Keep-Out Zones: Found 10 zone(s) - will be respected
Processing Target Area: GND, LayerName: F.Cu...
...
142 vias placed
Done!
```

## Breaking Changes / Compatibility

⚠️ **KiCad Version Compatibility:**

This PR is designed for **KiCad 9.0.x** and uses the new VECTOR2I-based API.

**Compatibility status:**
- ✅ **KiCad 9.0.x**: Fully compatible
- ❌ **KiCad 8.0 and earlier**: Requires API adjustments (see below)

### For KiCad 8.0 and Earlier

As the jsreynaud/kicad-action-scripts repository has branches for different KiCad versions I assume the master branch does not require backward compatibility:
- `master` branch → KiCad 9.0+
- `v6.0` branch → KiCad 6.0
- `v5.1` branch → KiCad 5.1

**Recommendation:** 
- Merge this PR into `master` branch for KiCad 9.0+
- Separate PRs can be created for older branches with API compatibility adjustments

### API Differences

The main API changes in KiCad 9.0 that affect this code:

1. **HitTestFilledArea()**: Changed from 3 parameters to 2
   - Old: `zone.HitTestFilledArea(layer, wxPoint, accuracy)`
   - New: `zone.HitTestFilledArea(layer, VECTOR2I)`

2. **Point types**: Changed from wxPoint to VECTOR2I
   - Old: `wxPoint(x, y)`
   - New: `VECTOR2I(x, y)`

If backward compatibility with KiCad 6.0-8.0 is needed, I can add version detection.

## Additional Notes

- Keep-out zones must be filled (press `B` in KiCad) to be detected
- Edge detection tests 8 points around via perimeter for accuracy
- Debug mode shows which vias are skipped due to keep-out zones

## Checklist

- [x] Code follows project style
- [x] Tested on KiCad 9.0.5
- [x] Addresses issue #80

## Future Enhancements

Potential improvements for future PRs:
- Migration to IPC API (when available for plugins)
- Visual preview of keep-out zones in plugin dialog
- Statistics showing zones and skipped positions