### PR TITLE
ViaStitching: respect keep-out zones defined inside footprints

### DIFF
--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -658,6 +658,11 @@ STEP         = '-'
             all_drawings = filter(lambda x: x.GetClass() == "PTEXT" and self.pcb.GetLayerID(x.GetLayerName()) in (F_Cu, B_Cu), self.pcb.Drawings())
             # wxPrint("exception on missing BOARD.DrawingsList")
         all_areas = [self.pcb.GetArea(i) for i in xrange(self.pcb.GetAreaCount())]
+        # Keep-out (rule) areas defined inside a footprint are not returned by
+        # BOARD.GetArea(); add them so vias are not placed inside footprint
+        # keep-out zones. They have no netname, so they never become target areas.
+        for footprint in self.pcb.GetFootprints():
+            all_areas += [zone for zone in footprint.Zones() if zone.GetIsRuleArea()]
         # target_areas    = filter(lambda x: (x.GetNetname().upper() == self.netname), all_areas)         # KeepOuts are filtered because they have no name
         # KeepOuts are filtered because they have no name
         target_areas = filter(lambda x: (x.GetNetname() == self.netname), all_areas)


### PR DESCRIPTION
## Summary

Keep-out (rule) areas that are defined **inside a footprint** are currently ignored during via placement, so stitching vias can be placed inside them.

`all_areas` is built from `BOARD.GetArea()` / `GetAreaCount()`, which only returns board-level zones (`m_zones`). Keep-out zones that live inside a footprint (`FOOTPRINT.Zones()`) are never included, so `CheckViaInAllAreas()` never sees them.

## Fix

Add the footprint-level rule areas to `all_areas`:

```python
for footprint in self.pcb.GetFootprints():
    all_areas += [zone for zone in footprint.Zones() if zone.GetIsRuleArea()]
```

The existing `CheckViaInAllAreas()` logic then excludes them, exactly as it already does for board-level keep-outs. Only rule areas are added, and they have no netname, so `target_areas` selection is unchanged.

## Verification

Tested with `pcbnew` 10.0.4 (headless) on a board with one board-level and one footprint-level keep-out zone, both disallowing vias:

| | board-level keep-out | footprint-level keep-out |
| --- | --- | --- |
| before | respected | **via placed inside (bug)** |
| after  | respected | respected |

`target_areas` selection is identical before and after.


## Related issues

Fixes #68 — mounting hole footprints carry their keep-out zone inside the footprint, which is exactly the case handled here.

Likely also fixes #80, if the ignored keep-out area under the connector belongs to the footprint rather than the board.
