### PR TITLE
Add KiCad 10 compatibility (SWIG plugins)

### DIFF
--- a/CircularZone/CircularZone.py
+++ b/CircularZone/CircularZone.py
@@ -28,7 +28,11 @@ class CircularZone(pcbnew.ActionPlugin):
         zone.SetOutline(sp)
         zone.SetLayer(pcbnew.F_Cu)
         zone.SetIsRuleArea(keepout)
-        zone.SetDoNotAllowCopperPour(keepout)
+        # Renamed to SetDoNotAllowZoneFills in KiCad 10
+        if hasattr(zone, "SetDoNotAllowCopperPour"):
+            zone.SetDoNotAllowCopperPour(keepout)
+        else:
+            zone.SetDoNotAllowZoneFills(keepout)
         zone.SetDoNotAllowFootprints(keepout)
         zone.SetDoNotAllowPads(keepout)
         zone.SetDoNotAllowTracks(keepout)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Please select the right branch according your KiCad version:
  - v7.0 for KiCad version 7.0.*
  - v8.0 for KiCad version 8.0.*
  - v9.0 for KiCad version 9.0.*
+ - master for KiCad version 9.0.* and 10.0.*
+
+Note: KiCad 10 still ships the (deprecated) SWIG based python
+bindings used by these plugins. They are planned to be removed in
+KiCad 11, which will require a rewrite to the new IPC API.
 
 # Know issues
 

--- a/ViaStitching/FillArea.py
+++ b/ViaStitching/FillArea.py
@@ -23,6 +23,7 @@
 from __future__ import print_function
 from pcbnew import *
 from builtins import abs
+import re
 import sys
 import tempfile
 import shutil
@@ -36,6 +37,40 @@ import time
 
 def wxPrint(msg):
     wx.LogMessage(msg)
+
+
+def GetKiCadMajorVersion():
+    # Version() returns a string, so comparisons like Version() < "7" break
+    # with KiCad 10 ("10..." < "7" is lexicographically true). Compare the
+    # major version numerically instead.
+    for name in ("GetMajorMinorVersion", "Version"):
+        func = globals().get(name)
+        if func is None:
+            continue
+        try:
+            match = re.search(r"\d+", func())
+            if match:
+                return int(match.group(0))
+        except Exception:
+            continue
+    return 0
+
+
+KICAD_VERSION_MAJOR = GetKiCadMajorVersion()
+
+
+def HitTestInsideZoneCompat(area, point):
+    # ZONE.HitTestInsideZone() was removed in KiCad 10; testing the zone
+    # outline is the equivalent operation.
+    if hasattr(area, "HitTestInsideZone"):
+        try:
+            return area.HitTestInsideZone(point)
+        except Exception:
+            pass
+    try:
+        return area.Outline().Collide(point)
+    except Exception:
+        return False
 
 
 #
@@ -297,7 +332,7 @@ STEP         = '-'
         for i in range(self.pcb.GetAreaCount()):
             area = self.pcb.GetArea(i)
             # No more making a real refill since it's crashing KiCad
-            if Version() < "7":
+            if KICAD_VERSION_MAJOR < 7:
                 None
             else:
                 area.SetNeedRefill(True)
@@ -312,7 +347,8 @@ STEP         = '-'
         # Enum all area
         for area in all_areas:
             area_layer = area.GetLayer()
-            area_clearance = area.GetLocalClearance()
+            # GetLocalClearance() may return None (std::optional) on newer KiCad versions
+            area_clearance = area.GetLocalClearance() or 0
             area_priority = area.GetAssignedPriority()
             is_rules_area = area.GetIsRuleArea()
             is_rule_exclude_via_area = area.GetIsRuleArea() and area.GetDoNotAllowVias()
@@ -329,7 +365,7 @@ STEP         = '-'
                         point_to_test = VECTOR2I(int(via.PosX + dx), int(via.PosY + dy))
 
                         hit_test_area = False
-                        if Version() < "7":
+                        if KICAD_VERSION_MAJOR < 7:
                             # below 7.0.0
                             for layer_id in area.GetLayerSet().CuStack():
                                 hit_test_area = hit_test_area or area.HitTestFilledArea(layer_id, point_to_test)  # Collides with a filled area
@@ -341,12 +377,7 @@ STEP         = '-'
                                     if area.GetLayerSet().Contains(layer_id) and (layer_id != Edge_Cuts):
                                         hit_test_area = hit_test_area or area_outline.PointInside(point_to_test)
                         hit_test_edge = area.HitTestForEdge(point_to_test, 1)  # Collides with an edge/corner
-                        try:
-                            hit_test_zone = area.HitTestInsideZone(point_to_test)  # Is inside a zone (e.g. KeepOut/Rules)
-                        except:
-                            hit_test_zone = False
-                            # wxPrint('exception: missing HitTestInsideZone: To Be Fixed (not available in kicad 7.0)')
-                            # hit_test_zone   = area.HitTest(point_to_test)
+                        hit_test_zone = HitTestInsideZoneCompat(area, point_to_test)  # Is inside a zone (e.g. KeepOut/Rules)
 
                         # Is inside a zone (e.g. KeepOut/Rules with via exlusion) kicad
                         if is_rule_exclude_via_area and (hit_test_area or hit_test_edge or hit_test_zone):
@@ -359,11 +390,12 @@ STEP         = '-'
                         elif (not self.via_through_areas) and hit_test_zone and not is_rules_area:
                             # Check if the zone is higher priority than other zones of the target net in the same point
                             # target_areas_on_same_layer = filter(lambda x: ((x.GetPriority() > area_priority) and (x.GetLayer() == area_layer) and (x.GetNetname().upper() == self.netname)), all_areas)
+                            # ZONE.GetPriority() no longer exists in KiCad 10, use GetAssignedPriority()
                             target_areas_on_same_layer = filter(
-                                lambda x: ((x.GetPriority() > area_priority) and (x.GetLayer() == area_layer) and (x.GetNetname() == self.netname)), all_areas
+                                lambda x: ((x.GetAssignedPriority() > area_priority) and (x.GetLayer() == area_layer) and (x.GetNetname() == self.netname)), all_areas
                             )
                             for area_with_higher_priority in target_areas_on_same_layer:
-                                if area_with_higher_priority.HitTestInsideZone(point_to_test):
+                                if HitTestInsideZoneCompat(area_with_higher_priority, point_to_test):
                                     break  # Area of target net has higher priority on this layer
                             else:
                                 # Collides with another signal (e.g. on another layer)
@@ -478,7 +510,7 @@ STEP         = '-'
             # For KiCad >= 7, zone.Outline() may return an empty SHAPE_POLY_SET for inner-layer
             # zones. We therefore try to build the polygon from points directly.
             zone_poly = SHAPE_POLY_SET()
-            if Version() < "7":
+            if KICAD_VERSION_MAJOR < 7:
                 for layer_id in zone.GetLayerSet().CuStack():
                     z = zone.RawPolysList(layer_id)
                     if z.OutlineCount() > 0:
@@ -664,7 +696,11 @@ STEP         = '-'
 
         # Get the board outline and size with
         board_edge = SHAPE_POLY_SET()
-        self.pcb.GetBoardPolygonOutlines(board_edge)
+        try:
+            self.pcb.GetBoardPolygonOutlines(board_edge)
+        except TypeError:
+            # KiCad 10 added a required aInferOutlineIfNecessary argument
+            self.pcb.GetBoardPolygonOutlines(board_edge, True)
         b_clearance = max(self.pcb.GetDesignSettings().m_CopperEdgeClearance, self.clearance) + self.size
         board_edge.Deflate(int(b_clearance), CORNER_STRATEGY_ROUND_ALL_CORNERS, FromMM(0.01))
 
@@ -679,7 +715,8 @@ STEP         = '-'
             if self.parent_area is None:
                 self.parent_area = area
             is_selected_area = area.IsSelected()
-            area_clearance = area.GetLocalClearance()
+            # GetLocalClearance() may return None (std::optional) on newer KiCad versions
+            area_clearance = area.GetLocalClearance() or 0
             if max_target_area_clearance < area_clearance:
                 max_target_area_clearance = area_clearance
 
@@ -703,7 +740,7 @@ STEP         = '-'
                             offset = 0  # Use an exact zone match
                             point_to_test = VECTOR2I(int(current_x), int(current_y))
                             hit_test_area = False
-                            if Version() < "7":
+                            if KICAD_VERSION_MAJOR < 7:
                                 # below 7.0.0
                                 hit_test_area = area.HitTestFilledArea(area.GetLayer(), VECTOR2I(point_to_test), int(offset))  # Collides with a filled area
                             else:


### PR DESCRIPTION
KiCad 10 ships with the SWIG python bindings still in place, but several APIs used by these plugins were removed or changed, and a latent version-comparison bug is triggered by the two-digit major version. This PR makes ViaStitching and CircularZone work on KiCad 10 while remaining compatible with KiCad 9 (and keeping the pre-7 code paths intact).

## Fixes

- **Version comparison**: `Version() < "7"` compares strings, so `"10.x" < "7"` is lexicographically true and KiCad 10 took the pre-7 code paths (crashing on the removed `RawPolysList()` API). The major version is now parsed and compared numerically.
- **`ZONE.HitTestInsideZone()`** was removed in KiCad 10. A compat helper falls back to `Outline().Collide(point)`, which is the equivalent operation.
- **`ZONE.GetPriority()`** was removed; the still-active call in `CheckViaInAllAreas()` now uses `GetAssignedPriority()` (already used elsewhere in the file).
- **`SetDoNotAllowCopperPour()`** was renamed to `SetDoNotAllowZoneFills()`; CircularZone now calls whichever exists.
- **`BOARD.GetBoardPolygonOutlines()`** gained a required `aInferOutlineIfNecessary` argument; handled via a `TypeError` fallback.
- **`GetLocalClearance()`** returns `None` (`std::optional`) on newer KiCad versions; guarded with `or 0` so the `max()` comparisons don't raise.

## Testing

Verified on KiCad 10.0.4 (Windows): version detection returns 10, ViaStitching fills a multi-layer board respecting keep-out rule areas, and CircularZone creates both zone types. Behavior on KiCad 9 is unchanged (all touched call sites keep their previous code path where the old API exists).

## Related issues

Fixes #97 and addresses #92 (code side; installing through the Plugin Manager additionally needs a new packaged release).

Also removes the `HitTestInsideZone` exception reported in #64 by replacing the call with an outline-collide fallback.

Complements #98, which adds the IPC-based variant as the long-term path (#93).
